### PR TITLE
rework fathom devtools panel (fixes #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /addon/contentScript.js
 /addon/web-ext-artifacts
 /addon/train.js
+/addon/simmer.js
 /package-lock.json

--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ you do the supervision (labeling) of pages that have been bulk-collected. You
 can also use it as an alternative to bulk collection that lets you interact
 with each page before freezing.
 
-Load a page, visit the panel, and apply as many labels as you want to various
-page elements (a max of one label per element at the moment). When you're done,
-click Save to pull down a frozen version of the page. That sample is then ready
-to be used with the Trainer.
+Load a page, right click on the element you want to label and choose Inspect
+Element, which will open Firefox's developer tools. Switch to the Fathom tab
+and enter the label for the inspected element.
+
+You can apply as many labels as you want to various page elements, with a max
+of one label per element at the moment. When you're done, click Save Page to
+pull down a frozen version of the page. That sample is then ready to be used
+with the Trainer.
 
 ## The Trainer
 

--- a/addon/background.js
+++ b/addon/background.js
@@ -1,5 +1,3 @@
-// We've proven we can console.log from a promise then() callback in the bg script.
-
 /**
  * Connect a dev panel, at its request, to the content script in its inspected
  * tab.
@@ -7,33 +5,48 @@
 function connectADevPanel(port) {
     // Open a port to our content script on the tab that's being inspected.
     port.onMessage.addListener(handleMessage);
+
     /**
      * Handle any of the various messages that can come flying at the
      * background script from various sources.
      */
     async function handleMessage(request) {
-        if (request.type === 'label') {
-            // console.log('Sending one-off message to tab', request.tabId);
-            const stuff = await browser.tabs.sendMessage(request.tabId, request);
-            // console.log('Received stuff from content script:', stuff);
-            // Then send via the port to devpanel.
-        } else if (request.type === 'freeze') {
-            const html = await browser.tabs.sendMessage(
-                request.tabId,
-                {type: 'freeze',
-                 inspectedElement: request.inspectedElement,
-                 options: request.options});
-            download(html, {saveAs: true});
-        } else if (request.type === 'showHighlight') {
-            browser.tabs.sendMessage(
-                request.tabId,
-                {type: 'showHighlight',
-                 inspectedElement: request.inspectedElement});
-        } else if (request.type === 'hideHighlight') {
-            browser.tabs.sendMessage(request.tabId, {type: 'hideHighlight'});
+        if (request.type === 'freeze') {
+            // Send 'freeze' request to content-script to fetch frozen html
+            browser.tabs.sendMessage(request.tabId, request)
+                .then((html) => {
+                    // Show save file dialog.  When the dialog is closed send a 'refresh'
+                    // message to the devpanel so it can hide the spinner.
+                    download(html, {saveAs: true})
+                        .then(() => {
+                            browser.runtime.sendMessage({type: 'refresh'});
+                        })
+                        .catch(() => {
+                            browser.runtime.sendMessage({type: 'refresh'});
+                        });
+                });
+
+        } else {
+            // Most requests are passed unmodified to the content script.
+            await browser.tabs.sendMessage(request.tabId, request);
         }
     }
 }
 browser.runtime.onConnect.addListener(connectADevPanel);
 
-// Use tabs.connect() and runtime.onConnect to connect from here to a content script.
+// Bridge between content and the devtools panel.
+browser.runtime.onMessage.addListener((request) => {
+    if (request.type === 'refresh') {
+        browser.runtime.sendMessage({type: 'refresh'}).catch(() => {});
+    }
+});
+
+// Update devtools panel when tab navigates to new page.
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
+    if (tabInfo.status === 'complete') {
+        browser.runtime.sendMessage({type: 'init'})
+            .catch((error) => {
+                console.error(error)
+            });
+    }
+});

--- a/addon/devtoolsPanel.js
+++ b/addon/devtoolsPanel.js
@@ -1,47 +1,232 @@
 let backgroundPort = browser.runtime.connect();
 
-function updateUi(evalResult) {
-    if (!isError(evalResult)) {
-        const firstLabeledElementId = evalResult[0];
-        console.log(`result: ${firstLabeledElementId}`);
-        document.getElementById('smoo').innerHTML = firstLabeledElementId;
-    }
-}
+function initPanel() {
+    // Initialise freeze-page button.
+    document.getElementById('freeze-button').addEventListener('click', () => {
+        document.getElementById('freeze-button').disabled = true;
+        document.getElementById('spinner-container').classList.remove('hidden');
+        inspectedElementSelector()
+            .then((selector) => {
+                backgroundPort.postMessage({
+                    type: 'freeze',
+                    tabId: browser.devtools.inspectedWindow.tabId,
+                    selector: selector,
+                    options: {shouldScroll: false, wait: 0},
+                });
+            }).catch((e) => {
+                console.error(e);
+            });
 
-async function labelInspectedElement() {
-    /**
-     * The function embedded herein returns an "index path" to the inspected
-     * element. A return value like [1, 4, 0] means the element could be found by
-     * going into the 0th element of the document (usually an <html> tag), then the
-     * 4th child of that tag, then finding the 1st child of that tag.
-     */
-    backgroundPort.postMessage({type: 'label',
-                                tabId: browser.devtools.inspectedWindow.tabId,
-                                inspectedElement: await inspectedElementPath(),
-                                label: document.getElementById('labelField').value});
-}
-document.getElementById('labelButton').addEventListener('click', labelInspectedElement);
+    });
 
-async function freezePage() {
-    backgroundPort.postMessage({type: 'freeze',
-                                tabId: browser.devtools.inspectedWindow.tabId,
-                                inspectedElement: await inspectedElementPath(),
-                                options: {shouldScroll: false, wait: 0}});
-}
-document.getElementById('saveButton').addEventListener('click', freezePage);
+    // Initialise content-script.
+    backgroundPort.postMessage({
+        type: 'init',
+        tabId: browser.devtools.inspectedWindow.tabId,
+    });
 
-/**
- * Update the GUI to reflect the currently inspected page the first time the
- * panel loads.
- *
- * This runs once per Fathom dev-panel per inspected page. (When you navigate
- * to a new page, the Console pane comes forward, so this re-runs when the
- * Fathom pane is brought forward again. It does not run twice when you switch
- * away from and then back to the Fathom dev panel. Contents of the dev panel
- * are preserved across that interaction.)
- */
-async function initPanel() {
-    // When we load a new page with existing annotations:
-    //browser.devtools.inspectedWindow.eval(`document.querySelectorAll("[data-fathom]")[0].id`).then(updateUi);
+    // And initialise the UI.
+    updateLabeled();
 }
 initPanel();
+
+// Handle requests from background script.
+browser.runtime.onMessage.addListener((request) => {
+    if (request.type === 'init') {
+        resetFreeze();
+        backgroundPort.postMessage({
+            type: 'init',
+            tabId: browser.devtools.inspectedWindow.tabId,
+        });
+        updateLabeled();
+
+    } else if (request.type === 'refresh') {
+        resetFreeze();
+        browser.runtime.sendMessage({type: 'init'})
+            .then(updateLabeled)
+            .catch((error) => {
+                console.error(error);
+            });
+    }
+});
+
+// Restore the freeze button and spinner back to original state.
+function resetFreeze() {
+    document.getElementById('freeze-button').disabled = false;
+    document.getElementById('spinner-container').classList.add('hidden');
+}
+
+// Returns a list of objects with the following attributes:
+//   preview: html preview of element
+//   label: the fathom label, or an empty string if unlabeled
+//   path: css path to element
+//   inspected: true if this element === $0
+function getLabeled() {
+    let evalScript = `
+        (function getLabeled() {
+            function elementMeta(el, isInspected) {
+                return {
+                    preview: el.outerHTML.replace(/^([^>]+>)[\\s\\S]*$/, '$1'),
+                    label: el.dataset.fathom || '',
+                    path: Simmer(el),
+                    inspected: isInspected,
+                };
+            }
+
+            let list = [];
+            if ($0) {
+                list.push(elementMeta($0, true));
+            }
+            for (const el of document.querySelectorAll('[data-fathom]')) {
+                if ($0 && el === $0) {
+                    continue;
+                }
+                list.push(elementMeta(el, false));
+            }
+            return list;
+        })();
+    `;
+    return resultOfEval(evalScript);
+}
+
+// Draw the table with the list of existing labeled elements.
+// If an element is inspected/selected with devtools (i.e. $0 is defined), it
+// will always be the first row in the table.
+function updateLabeledTable(labeled) {
+
+    function addTextCell(row, text, isHeader=false) {
+        const td = document.createElement(isHeader ? 'th' : 'td');
+        td.appendChild(document.createTextNode(text));
+        row.appendChild(td);
+        return td;
+    }
+
+    function inspectLabeled(event) {
+        event.preventDefault();
+        const js = 'inspect(document.querySelector("' + event.target.dataset.path + '"))';
+        browser.devtools.inspectedWindow.eval(js)
+            .catch((e) => {
+                console.error(e);
+            });
+    }
+
+    function addPathCell(row, label) {
+        const td = document.createElement('td');
+        td.classList.add('path');
+        if (label.inspected) {
+            td.appendChild(document.createTextNode(label.path));
+        } else {
+            let a = document.createElement('a');
+            a.href = '#';
+            a.dataset.path = label.path;
+            a.addEventListener('click', inspectLabeled);
+            a.appendChild(document.createTextNode(label.path));
+            td.appendChild(a);
+        }
+        row.appendChild(td);
+    }
+
+    function updateLabel(event) {
+        backgroundPort.postMessage({
+            type: 'label',
+            tabId: browser.devtools.inspectedWindow.tabId,
+            selector: event.target.dataset.path,
+            label: event.target.value.trim(),
+        });
+    }
+
+    function addLabelCell(row, label) {
+        const td = document.createElement('td');
+        td.classList.add('label');
+        const input = document.createElement('input');
+        input.setAttribute('placeholder', 'unlabeled');
+        input.value = label.label;
+        input.dataset.path = label.path;
+        input.addEventListener('change', updateLabel);
+        td.appendChild(input);
+        row.appendChild(td);
+    }
+
+    function removeLabeled(event) {
+        event.preventDefault();
+        backgroundPort.postMessage({
+            type: 'label',
+            tabId: browser.devtools.inspectedWindow.tabId,
+            selector: event.target.dataset.path,
+            label: '',
+        });
+    }
+
+    function addClearLabelCell(row, label) {
+        const td = document.createElement('td');
+        td.classList.add('action');
+        const a = document.createElement('a');
+        a.href = '#';
+        a.classList.add('action-button');
+        a.dataset.path = label.path;
+        a.dataset.label = label.label;
+        a.setAttribute('title', label.inspected ? 'Clear Label' : 'Remove Label');
+        a.addEventListener('click', removeLabeled);
+        a.appendChild(document.createTextNode(label.inspected ? '⦸' : '✖'));
+        td.appendChild(a);
+        row.appendChild(td);
+    }
+
+    const table = document.createElement('table');
+    const headerRow = document.createElement('tr');
+    addTextCell(headerRow, 'Selector', true).classList.add('path');
+    addTextCell(headerRow, 'Element', true).classList.add('preview');
+    addTextCell(headerRow, 'Label', true).classList.add('label');
+    addTextCell(headerRow, '').classList.add('action');
+    table.appendChild(headerRow);
+
+    for (const label of labeled) {
+        const row = document.createElement('tr');
+        row.classList.add('hover');
+
+        addPathCell(row, label);
+        addTextCell(row, label.preview).classList.add('preview');
+        addLabelCell(row, label);
+        addClearLabelCell(row, label);
+
+        table.appendChild(row);
+    }
+
+    const container = document.getElementById('labels');
+    emptyElement(container);
+    container.appendChild(table);
+}
+
+// Update the UI to show either the table of labeled elements, or
+// a message informing the user to use the inspection panel.
+function updateLabeled() {
+    getLabeled()
+        .then((labeled) => {
+            updateLabeledTable(labeled);
+
+            if (labeled.length === 0) {
+                // nothing inspected or already labeled
+                document.getElementById('no-selection').classList.remove('hidden');
+                document.getElementById('no-labels').classList.add('hidden');
+                document.getElementById('labels').classList.add('hidden');
+
+            } else {
+                // show labels table
+                document.getElementById('no-labels').classList.add('hidden');
+                document.getElementById('labels').classList.remove('hidden');
+                // if the first item is unlabeled it's the inspected element
+                if (labeled[0].inspected) {
+                    // selection
+                    document.getElementById('no-selection').classList.add('hidden');
+                } else {
+                    // no selection
+                    document.getElementById('no-selection').classList.remove('hidden');
+                }
+
+
+            }
+        })
+        .catch((error) => {
+            console.error(error);
+        });
+}

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -18,8 +18,11 @@
     },
     "content_scripts": [{
         "matches": ["<all_urls>"],
-        "js": ["utils.js", "contentScript.js"]
+        "js": ["utils.js", "contentScript.js", "simmer.js"]
     }],
+    "web_accessible_resources": [
+        "simmer.js"
+    ],
     "permissions": [
         "<all_urls>",
         "downloads",

--- a/addon/pages/devtoolsPanel.html
+++ b/addon/pages/devtoolsPanel.html
@@ -110,7 +110,7 @@
   <body class="browser-style">
     <div id="current-labels" class="box">
       <div id="no-selection" class="hidden">
-        No currently selected element - use the DevTools <b>Inspector</b> to select an element.
+        No currently selected element&mdash;use the DevTools <b>Inspector</b> to select an element.
       </div>
       <div id="no-labels" class="hidden">
         No labeled elements found.

--- a/addon/pages/devtoolsPanel.html
+++ b/addon/pages/devtoolsPanel.html
@@ -3,19 +3,129 @@
   <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" type="text/css" href="chrome://browser/content/extension.css">
+    <style>
+      .hidden {
+        display: none !important;
+      }
+
+      body {
+        padding: 10px;
+      }
+
+      h1 {
+        margin: 0 0 10px 0;
+        font-size: 100%;
+      }
+
+      .box {
+        border: 1px solid silver;
+        padding: 10px;
+        margin-bottom: 10px;
+      }
+
+      #no-selection, #no-labels {
+        font-style: italic;
+      }
+
+      #has-selection label {
+        width: 50em;
+      }
+
+      #labels table {
+        border-spacing: 0;
+        padding: 0;
+      }
+
+      #labels .path, #labels .label, #labels .action {
+        white-space: nowrap;
+      }
+
+      #labels .preview {
+        width: 100%;
+      }
+
+      #labels td.preview {
+        font-family: monospace;
+        font-size: 90%;
+        max-height: 1em;
+      }
+
+      #labels tr.hover:hover {
+        background-color: #eee;
+      }
+
+      #labels .action-button {
+        color: #000;
+        text-decoration: none;
+        width: 1.5em;
+        display: inline-block;
+        text-align: center;
+      }
+
+      #labels .action-button:hover {
+        color: rebeccapurple;
+        outline: 1px solid #444;
+      }
+
+      #labels th, #labels td {
+        padding: 2px 5px;
+      }
+
+      #spinner-container {
+        display: inline-block;
+        color: #888;
+      }
+
+      #spinner {
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        margin: 0 8px;
+      }
+
+      #spinner:after {
+        content: " ";
+        display: block;
+        width: 0.5em;
+        height: 0.5em;
+        margin: 1px;
+        border-radius: 50%;
+        border: 5px solid #888;
+        border-color: #888 transparent #888 transparent;
+        animation: spinner 1.2s linear infinite;
+      }
+
+      @keyframes spinner {
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+
+    </style>
   </head>
-  <body class="browser-style" style="padding: 0 20px">
-    <p>
-      Use the devtools Inspector to select an element, then label it here. Once you have labeled all the interesting elements, save.
-    <p>
-    <div>
-      <button id="labelButton">Label the inspected element</button>
-      as
-      <input id="labelField" type="text">
+
+  <body class="browser-style">
+    <div id="current-labels" class="box">
+      <div id="no-selection" class="hidden">
+        No currently selected element - use the DevTools <b>Inspector</b> to select an element.
+      </div>
+      <div id="no-labels" class="hidden">
+        No labeled elements found.
+      </div>
+      <div id="labels" class="hidden"></div>
     </div>
-    <div>
-      <button id="saveButton">Save</button>
+
+    <div id="freeze-page-container">
+      <button id="freeze-button">Save Page...</button>
+      <div id="spinner-container" class="hidden">
+        <div id="spinner"></div>
+        Working...
+      </div>
     </div>
+
     <script src="../utils.js"></script>
     <script src="../devtoolsPanel.js"></script>
   </body>

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1,16 +1,4 @@
 /**
- * Return the DOM element indicated by an array of offsets as described in
- * elementPath().
- */
-function elementAtPath(path, document) {
-    let node = document;
-    for (const index of reversed(path)) {
-        node = node.children[index];
-    }
-    return node;
-}
-
-/**
  * Return the result of a browser.devtools.inspectedWindow.eval call. Throw the
  * error object on failure.
  */
@@ -23,45 +11,18 @@ async function resultOfEval(codeString) {
 }
 
 /**
- * Return an backward iterator over an Array.
+ * Deletes all children of the specified element.
  */
-function *reversed(array) {
-    for (let i = array.length - 1; i >= 0; i--) {
-        yield array[i];
+function emptyElement(element) {
+    while (element.firstChild) {
+        element.removeChild(element.firstChild);
     }
 }
 
-/**
- * Return an "index path" to the element inspected by the dev tools; undefined
- * if none is inspected.
- *
- * Callable only from devtools panels or openers.
- */
-async function inspectedElementPath() {
-    const inspectedElementPathSource = `
-        (function pathOfElement(element) {
-            function indexOf(arrayLike, item) {
-                for (let i = 0; i < arrayLike.length; i++) {
-                    if (arrayLike[i] === item) {
-                        return i;
-                    }
-                }
-                throw new Error('Item was not found in collection.');
-            }
-
-            if (element === undefined) {
-                return undefined;
-            }
-            const path = [];
-            let node = element;
-            while (node.parentNode !== null) {
-                path.push(indexOf(node.parentNode.children, node));
-                node = node.parentNode;
-            }
-            return path;
-        })($0)
-        `;
-    return resultOfEval(inspectedElementPathSource);
+// Requires simmer.js injected into current page.
+// simmer.js is injected when the devtools panel is initialised when first opened.
+async function inspectedElementSelector() {
+    return resultOfEval(`Simmer($0)`);
 }
 
 /**

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -11,6 +11,15 @@ async function resultOfEval(codeString) {
 }
 
 /**
+ * Return a backward iterator over an Array.
+ */
+function *reversed(array) {
+    for (let i = array.length - 1; i >= 0; i--) {
+        yield array[i];
+    }
+}
+
+/**
  * Deletes all children of the specified element.
  */
 function emptyElement(element) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.2.1",
     "rollup-plugin-node-resolve": "^3.3.0",
+    "rollup-plugin-copy": "^0.2.3",
+    "simmerjs": "^0.5.6",
     "web-ext": "^1.7.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import json from 'rollup-plugin-json';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';
+import copy from 'rollup-plugin-copy';
 
 /**
  * Return typical rollup settings for a file of a given name.
@@ -24,7 +25,10 @@ function mindlesslyFactoredOutSettings(name) {
             }),
             json(),
             globals(),
-            builtins()
+            builtins(),
+            copy({
+                'node_modules/simmerjs/dist/simmer.js': 'addon/simmer.js',
+            }),
         ]
     }
 }

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -71,6 +71,13 @@ function injectSimmer() {
     head.insertBefore(script, head.lastChild);
 }
 
+function removeSimmer() {
+    const simmerElement = document.getElementById('fathom-simmer');
+    if (simmerElement) {
+        simmerElement.parentNode.removeChild(simmerElement);
+    }
+}
+
 // Set or clear the label on the element specifed by request.selector.
 function setLabel(request) {
     // Find target element.
@@ -96,7 +103,13 @@ function setLabel(request) {
 // background script, so it can download the result when done.
 // Corpus collector calls directly.
 function freezePage(request) {
+    // Remove the simmer <script> element.  This doesn't need to be put back
+    // as the `Simmer` object will exist and won't need to be recreated.
+    removeSimmer();
+
+    // Remove the highlight/overlay.  This will need to be restored.
     hideHighlight();
+
     return freezeThisPage(request.options)
         .then((html) => {
             if (request.selector) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,6 +657,10 @@ colors@0.5.x:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
+colors@^1.1.2:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.1.tgz#4accdb89cf2cabc7f982771925e9468784f32f3d"
+
 columnify@1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -1443,6 +1447,14 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
 
+fs-extra@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs-extra@~2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
@@ -2045,6 +2057,12 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -2248,9 +2266,17 @@ lodash.defaults@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+
 lodash.filter@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
+
+lodash.flatmap@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz#ef8cbf408f6e48268663345305c6acc0b778702e"
 
 lodash.flatten@^4.2.0:
   version "4.4.0"
@@ -2259,6 +2285,10 @@ lodash.flatten@^4.2.0:
 lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.isfunction@^3.0.8:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
 
 lodash.map@^4.4.0:
   version "4.6.0"
@@ -2287,6 +2317,14 @@ lodash.reject@^4.4.0:
 lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
+lodash.take@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.take/-/lodash.take-4.1.1.tgz#0b4146dcb7a70c6153495187fc10b12b71fefadf"
+
+lodash.takeright@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.takeright/-/lodash.takeright-4.1.1.tgz#c98d84aa9b80e4d2ff675335a62e02e9a65bb210"
 
 lodash@3.10.1:
   version "3.10.1"
@@ -3199,6 +3237,13 @@ rollup-plugin-commonjs@^9.1.3:
     resolve "^1.5.0"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-copy@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-copy/-/rollup-plugin-copy-0.2.3.tgz#dac1ab81d1f220baeb98e5c4c0108252e1edbb98"
+  dependencies:
+    colors "^1.1.2"
+    fs-extra "^3.0.0"
+
 rollup-plugin-json@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-3.0.0.tgz#aeed2ff36e6c4fd0c60c4a8fc3d0884479e9dfce"
@@ -3363,6 +3408,16 @@ sign-addon@0.2.1:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simmerjs@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/simmerjs/-/simmerjs-0.5.6.tgz#4bba4fd4cbac18d889037aa199dd742dd1402b96"
+  dependencies:
+    lodash.difference "^4.5.0"
+    lodash.flatmap "^4.5.0"
+    lodash.isfunction "^3.0.8"
+    lodash.take "^4.1.1"
+    lodash.takeright "^4.1.1"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -3685,6 +3740,10 @@ unique-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
   dependencies:
     crypto-random-string "^1.0.0"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
 unzip-response@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
- change ui for labeling inspected element
- add list of already labeled elements, with ability to edit/clear inline
- switch from oid style selectors to css path (via the simmer library)
- add spinner to freeze action