### PR TITLE
Increase the max CSS selector depth (fixes #13)

### DIFF
--- a/addon/devtoolsPanel.js
+++ b/addon/devtoolsPanel.js
@@ -111,6 +111,13 @@ function updateLabeledTable(labeled) {
             });
     }
 
+    function addErrorRow(table, error) {
+        const row = document.createElement('tr');
+        row.classList.add('error');
+        addTextCell(row, error).setAttribute('colspan', '3');
+        table.appendChild(row);
+    }
+
     function addPathCell(row, label) {
         const td = document.createElement('td');
         td.classList.add('path');
@@ -182,6 +189,11 @@ function updateLabeledTable(labeled) {
     table.appendChild(headerRow);
 
     for (const label of labeled) {
+        if (!label.path) {
+            addErrorRow(table, 'Failed to calculate CSS selector for the inspected element');
+            continue;
+        }
+
         const row = document.createElement('tr');
         row.classList.add('hover');
 

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -67,8 +67,12 @@ function injectSimmer() {
     const script = document.createElement('script');
     script.setAttribute('id', 'fathom-simmer');
     script.setAttribute('src', browser.extension.getURL('simmer.js'));
-    const head = document.head || document.getElementsByTagName('head')[0] || document.documentElement;
-    head.insertBefore(script, head.lastChild);
+    script.setAttribute('onload', `
+        window.Simmer = window.Simmer.configure({
+            depth: 25
+        });
+    `);
+    document.head.appendChild(script);
 }
 
 function removeSimmer() {
@@ -80,6 +84,10 @@ function removeSimmer() {
 
 // Set or clear the label on the element specifed by request.selector.
 function setLabel(request) {
+    if (!request.selector) {
+        return;
+    }
+
     // Find target element.
     const inspectedElement = document.querySelector(request.selector);
     if (!inspectedElement) {
@@ -127,6 +135,10 @@ function freezePage(request) {
  */
 function showHighlight(selector) {
     hideHighlight();
+
+    if (!selector) {
+        return;
+    }
 
     const element = document.querySelector(selector);
     if (!element) {


### PR DESCRIPTION
- increase Simmer's max CSS selector depth from 3 to 25
- if Simmer fails, show an error message instead of `false`