### PR TITLE
Automatically retrieves viewport size from trainee instead of manually

### DIFF
--- a/addon/corpus.js
+++ b/addon/corpus.js
@@ -12,8 +12,6 @@ class CorpusCollector extends PageVisitor {
             wait: parseFloat(this.doc.getElementById('wait').value),
             shouldScroll: this.doc.getElementById('shouldScroll').checked,
         };
-        options.viewportWidth = parseInt(this.doc.getElementById('viewportWidth').value);
-        options.viewportHeight = parseInt(this.doc.getElementById('viewportHeight').value);
 
         // Note we extend the timeout by the freeze delay.
         options.timeout = parseFloat(this.doc.getElementById('timeout').value) + options.otherOptions.wait;
@@ -53,6 +51,13 @@ class CorpusCollector extends PageVisitor {
             return undefined;
         }
         return options;
+    }
+
+    async getViewportHeightAndWidth() {
+        return {
+            height: parseInt(this.doc.getElementById('viewportHeight').value),
+            width: parseInt(this.doc.getElementById('viewportWidth').value)
+        }
     }
 
     async processWithinTimeout(tab) {

--- a/addon/pages/vector.html
+++ b/addon/pages/vector.html
@@ -55,14 +55,6 @@
           <input class="number" type="text" required pattern="[0-9]+" min="0" size="2" id="wait" value="1"> sec
         </div>
         <div>
-          <label title="Resize the window so the viewport is this big.">
-            Viewport Size:
-            <input class="number" type="text" required pattern="[0-9]+" size="4" id="viewportWidth" value="1024">
-            ×
-            <input class="number" type="text" required pattern="[0-9]+" size="4" id="viewportHeight" value="768">
-          </label>
-        </div>
-        <div>
           <label for="baseUrl" title="This gets prepended to each page title to make a URL.">Base URL:</label>
           <input type="text" size="30" id="baseUrl" value="http://127.0.0.1:8000/training/">
         </div>

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -38,7 +38,7 @@ class CorpusCollector extends PageVisitor {
         const trainee = await browser.runtime.sendMessage(
             'fathomtrainees@mozilla.com',
             {type: 'trainee',
-                traineeId: this.otherOptions.traineeId});
+            traineeId: this.otherOptions.traineeId});
 
         return {
             'height': trainee.viewportSize.height,

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -29,7 +29,21 @@ class CorpusCollector extends PageVisitor {
             wait: parseInt(this.doc.getElementById('wait').value),
             retryOnError: this.doc.getElementById('retryOnError').checked
         };
+
         return options;
+    }
+
+    async getViewportHeightAndWidth() {
+        // Pull the viewport size from the loaded trainee.
+        const trainee = await browser.runtime.sendMessage(
+            'fathomtrainees@mozilla.com',
+            {type: 'trainee',
+                traineeId: this.otherOptions.traineeId});
+
+        return {
+            'height': trainee.viewportSize.height,
+            'width': trainee.viewportSize.width
+        }
     }
 
     async processWithinTimeout(tab) {

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -38,7 +38,7 @@ class CorpusCollector extends PageVisitor {
         const trainee = await browser.runtime.sendMessage(
             'fathomtrainees@mozilla.com',
             {type: 'trainee',
-            traineeId: this.otherOptions.traineeId});
+             traineeId: this.otherOptions.traineeId});
 
         return {
             height: trainee.viewportSize.height,

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -41,8 +41,8 @@ class CorpusCollector extends PageVisitor {
             traineeId: this.otherOptions.traineeId});
 
         return {
-            'height': trainee.viewportSize.height,
-            'width': trainee.viewportSize.width
+            height: trainee.viewportSize.height,
+            width: trainee.viewportSize.width
         }
     }
 

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -7,9 +7,6 @@ class CorpusCollector extends PageVisitor {
         const options = {};
 
         // Initialize options from the form.
-        options.viewportWidth = parseInt(this.doc.getElementById('viewportWidth').value);
-        options.viewportHeight = parseInt(this.doc.getElementById('viewportHeight').value);
-
         options.timeout = 9999;  // effectively none
 
         // Load each url line-by-line from the textarea.

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -11,7 +11,7 @@ class PageVisitor {
      *     invalid or contains no URLs, return undefined instead.
      */
     // formOptions() {
-    // 
+    //
     // }
 
     constructor(document) {
@@ -49,9 +49,15 @@ class PageVisitor {
         }
         this.urls = options.urls;
         this.timeout = options.timeout;
-        this.viewportWidth = options.viewportWidth;
-        this.viewportHeight = options.viewportHeight;
         this.otherOptions = options.otherOptions;
+
+        const trainee = await browser.runtime.sendMessage(
+            'fathomtrainees@mozilla.com',
+            {type: 'trainee',
+                traineeId: this.otherOptions.traineeId});
+
+        this.viewportHeight = trainee.viewportSize.height;
+        this.viewportWidth = trainee.viewportSize.width;
 
         emptyElement(document.getElementById('status'));
 

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -5,10 +5,10 @@ class PageVisitor {
     /**
      * Return a collection of user input from the form.
      *
-     * @return {urls, timeout, viewportWidth, viewportHeight, otherOptions}, where
-     *     `otherOptions` is an object encapsulating options specific to the
-     *     PageVisitor subclass, opaque to the superclass. If the form data is
-     *     invalid or contains no URLs, return undefined instead.
+     * @return {urls, timeout, otherOptions}, where `otherOptions` is an
+     *     object encapsulating options specific to the PageVisitor subclass,
+     *     opaque to the superclass. If the form data is invalid or contains
+     *     no URLs, return undefined instead.
      */
     // formOptions() {
     //
@@ -51,16 +51,9 @@ class PageVisitor {
         this.timeout = options.timeout;
         this.otherOptions = options.otherOptions;
 
-        // If the subclass's form does not provide the viewport size, it should
-        // have a method to provide that information in a different way.
-        if (options.hasOwnProperty('viewportHeight')) {
-            this.viewportHeight = options.viewportHeight;
-            this.viewportWidth = options.viewportWidth;
-        } else {
-            const viewportSize = await this.getViewportHeightAndWidth();
-            this.viewportHeight = viewportSize.height;
-            this.viewportWidth = viewportSize.width;
-        }
+        const viewportSize = await this.getViewportHeightAndWidth();
+        this.viewportHeight = viewportSize.height;
+        this.viewportWidth = viewportSize.width;
 
         emptyElement(document.getElementById('status'));
 
@@ -221,7 +214,7 @@ class PageVisitor {
     async processAtEndOfRun() {
     }
 
-    // This is used to get the viewport size if it is not in the PageVisitor's form.
+    // This is used to get the viewport size.
     async getViewportHeightAndWidth() {
 
     }

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -2,18 +2,6 @@
 // them
 
 class PageVisitor {
-    /**
-     * Return a collection of user input from the form.
-     *
-     * @return {urls, timeout, otherOptions}, where `otherOptions` is an
-     *     object encapsulating options specific to the PageVisitor subclass,
-     *     opaque to the superclass. If the form data is invalid or contains
-     *     no URLs, return undefined instead.
-     */
-    // formOptions() {
-    //
-    // }
-
     constructor(document) {
         this.urls =[];  // Array of {filename, url} to visit
         this.urlIndex = undefined;  // index of current URL in this.urls
@@ -214,9 +202,21 @@ class PageVisitor {
     async processAtEndOfRun() {
     }
 
+    /**
+     * Return a collection of user input from the form.
+     *
+     * @return {urls, timeout, otherOptions}, where `otherOptions` is an
+     *     object encapsulating options specific to the PageVisitor subclass,
+     *     opaque to the superclass. If the form data is invalid or contains
+     *     no URLs, return undefined instead.
+     */
+    formOptions() {
+        throw new Error('You must implement formOptions()')
+    }
+
     // This is used to get the viewport size.
     async getViewportHeightAndWidth() {
-
+        throw new Error('You must implement getViewportHeightAndWidth()')
     }
 
     setCurrentStatus({message, isFinal=false, isError=false}) {

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -51,13 +51,16 @@ class PageVisitor {
         this.timeout = options.timeout;
         this.otherOptions = options.otherOptions;
 
-        const trainee = await browser.runtime.sendMessage(
-            'fathomtrainees@mozilla.com',
-            {type: 'trainee',
-                traineeId: this.otherOptions.traineeId});
-
-        this.viewportHeight = trainee.viewportSize.height;
-        this.viewportWidth = trainee.viewportSize.width;
+        // If the subclass's form does not provide the viewport size, it should
+        // have a method to provide that information in a different way.
+        if (options.hasOwnProperty('viewportHeight')) {
+            this.viewportHeight = options.viewportHeight;
+            this.viewportWidth = options.viewportWidth;
+        } else {
+            const viewportSize = await this.getViewportHeightAndWidth();
+            this.viewportHeight = viewportSize.height;
+            this.viewportWidth = viewportSize.width;
+        }
 
         emptyElement(document.getElementById('status'));
 
@@ -216,6 +219,11 @@ class PageVisitor {
 
     // This runs after the last page is processed.
     async processAtEndOfRun() {
+    }
+
+    // This is used to get the viewport size if it is not in the PageVisitor's form.
+    async getViewportHeightAndWidth() {
+
     }
 
     setCurrentStatus({message, isFinal=false, isError=false}) {


### PR DESCRIPTION
Addresses issue #32 

Currently, users have to fill in the size of the viewport for vectorizing in the form on the vectoizer page. The user usually references the values in their `trainees.js` file, and has to re-enter the values every time they reopen the vectorizer (not refresh though).

This pull request uses the message passing already contained in FathomFox to automatically retrieve the viewport size from `trainees.js` so the user never has to worry about potential mismatches. This pull request also removes the viewport fields from the form on the vectorizer page since they are no longer needed.

An implementation note/question for @erikrose : I am unsure about making the `sendMessage()` call in `visit.js`. It feels like it belongs in `vector.js`, but there isn't a great place for it. My first inclination was to put the call in `visit.js`'s `processAtBeginningOfRun()` method, but the `traineeId` has not yet been retrieved at that point (this occurs in `formOptions()`). So, the other option I see is to create a new method within `CorpusCollector` to get the viewport size and call that method from `visit.js`.