### PR TITLE
Check for nulls

### DIFF
--- a/addon/vector.js
+++ b/addon/vector.js
@@ -74,7 +74,21 @@ class CorpusCollector extends PageVisitor {
         }
         if (vector !== undefined) {
             this._vectors.push(vector);
-            this.setCurrentStatus({message: 'vectorized', isFinal: true});
+
+            // Check if any of the rules didn't run or returned null.
+            // This presents as an undefined value in a feature vector.
+            if (vector.nodes.some(
+                node => node.features.some(
+                    feature => feature === undefined
+                )
+            )) {
+                this.setCurrentStatus({
+                    message: 'warning: null values in vector. one or more rules returned null',
+                    isFinal: true
+                });
+            } else {
+                this.setCurrentStatus({message: 'vectorized', isFinal: true});
+            }
         }
     }
 

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -81,7 +81,7 @@ class CorpusCollector extends PageVisitor {
             if (nullFeatures) {
                 console.log(nullFeatures);
                 this.setCurrentStatus({
-                    message: 'warning: rule(s) ' + nullFeatures + ' returned null values',
+                    message: 'failed: rule(s) ' + nullFeatures + ' returned null values',
                     isFinal: true
                 });
             } else {


### PR DESCRIPTION
Addresses #35 

This PR adds a check for `undefined` feature values during vectorization. This allows you to notice a certain class of ruleset errors during vectorization instead of during training.

If an `undefined` value is seen, the vectorizer will output a failure message and tell you what rules had `undefined` values.

One thing I do not like about this is that I am requesting the feature names every time an `undefined` value is seen. We could get the feature names sooner and make them class attributes. This increases the size of the class a little, and though we do need the feature names regardless in `visit.js`'s `processAtEndOfRun()`, `corpus.js` doesn't need the feature names at all.