### PR TITLE
Removes ability to Train and Pause on the Trainer page

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 addon/contentScript.js
-addon/train.js
+addon/evaluate.js
 addon/simmer.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /node_modules
 /addon/contentScript.js
 /addon/web-ext-artifacts
-/addon/train.js
+/addon/evaluate.js
 /addon/simmer.js
 /package-lock.json

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can apply as many labels as you want to various page elements, though there 
 
 ## Vectorizer
 
-Once you've labeled your corpus, you'll need a file of feature vectors you can feed to the trainer.
+Once you've labeled your corpus, you'll need a file of feature vectors you can feed to the [training commandline tool](https://mozilla.github.io/fathom/training.html#running-the-trainer).
 
 1. Open the Vectorizer from FathomFox's toolbar button. 
 2. Give the Vectorizer a list of your labeled pages' filenames.
@@ -44,11 +44,9 @@ Once you've labeled your corpus, you'll need a file of feature vectors you can f
 
 The Retry on Error checkbox should generally stay on, to work around apparently unavoidable spurious errors in the web extension communication APIs. However, turn it off during ruleset debugging; that way, you can see your actual mistakes more promptly.
 
-## Trainer
+## Evaluator
 
-The actual training functionality of the FathomFox Trainer is deprecated in favor of the much more efficient [commandline tool](https://mozilla.github.io/fathom/training.html#running-the-trainer), but its Evaluate function is still useful for debugging.
-
-Once you have a decent set of coefficients and biases computed, sub them into your ruleset, open some troublesome pages in a Firefox window, and invoke the FathomFox Trainer. From there, click Evaluate to run the ruleset over the loaded tabs. Any pages with misrecognized nodes will show up in red; click those to see which element was wrongly selected. Unfortunately, you need to manually show the dev tools and switch to the Fathom panel once you get to the page in question; there aren't yet web extension APIs to do it automatically. Once you do, you'll see a quick and dirty representation of the "bad" element: a new label called "BAD [the trainee ID]". Be sure to delete this if you choose to re-save the page for some reason. Also note that the BAD label is created only when the bad cell is clicked, for speed; if you navigate to the bad page manually, the label won't be there, or there might be an old label from a previous iteration.
+Once you have a decent set of coefficients and biases computed, sub them into your ruleset, open some troublesome pages in a Firefox window, and invoke the FathomFox Evaluator. From there, click Evaluate to run the ruleset over the loaded tabs. Any pages with misrecognized nodes will show up in red; click those to see which element was wrongly selected. Unfortunately, you need to manually show the dev tools and switch to the Fathom panel once you get to the page in question; there aren't yet web extension APIs to do it automatically. Once you do, you'll see a quick and dirty representation of the "bad" element: a new label called "BAD [the trainee ID]". Be sure to delete this if you choose to re-save the page for some reason. Also note that the BAD label is created only when the bad cell is clicked, for speed; if you navigate to the bad page manually, the label won't be there, or there might be an old label from a previous iteration.
 
 ## Tips
 

--- a/addon/actionMenu.js
+++ b/addon/actionMenu.js
@@ -4,5 +4,5 @@ function openTab(url) {
 }
 
 document.getElementById('collectCorpus').addEventListener('click', () => openTab('/pages/corpus.html'));
-document.getElementById('train').addEventListener('click', () => openTab('/pages/train.html'));
+document.getElementById('evaluate').addEventListener('click', () => openTab('/pages/evaluate.html'));
 document.getElementById('vectorize').addEventListener('click', () => openTab('/pages/vector.html'));

--- a/addon/pages/actionMenu.html
+++ b/addon/pages/actionMenu.html
@@ -8,8 +8,8 @@
       <div id="collectCorpus" class="panel-list-item">
         <div class="text">Corpus Collector</div>
       </div>
-      <div id="train" class="panel-list-item">
-        <div class="text">Trainer</div>
+      <div id="evaluate" class="panel-list-item">
+        <div class="text">Evaluator</div>
       </div>
       <div id="vectorize" class="panel-list-item">
         <div class="text">Vectorizer</div>

--- a/addon/pages/evaluate.html
+++ b/addon/pages/evaluate.html
@@ -122,7 +122,7 @@
         box-shadow: 0 0 0 2px rgba(97, 181, 255, 0.75);
       }
 
-      button#onlyOneStep {
+      button#evaluate {
         float: right;
       }
     </style>
@@ -148,9 +148,6 @@
         <button type="button" id="evaluate" class="browser-style">Evaluate</button>
       </div>
       <div>
-      </div>
-      <div>
-        <meter id="progress" class="hidden"></meter>
       </div>
       <div>
       </div>

--- a/addon/pages/evaluate.html
+++ b/addon/pages/evaluate.html
@@ -128,12 +128,12 @@
     </style>
   </head>
   <body class="browser-style" style="padding: 0 20px">
-    <h1>Trainer</h1>
+    <h1>Evaluator</h1>
     <p id="please-install" class="warning hidden">
       No rulesets found. Please install a “trainee” web extension containing your rulesets. For an example, see <a href="https://github.com/mozilla/fathom-trainees">Fathom Trainees</a>.
     </p>
     <p>
-      Optimize your ruleset’s weighting coefficients based on the samples you’ve loaded as tabs in this window.
+      Evaluate your ruleset based on the samples you’ve loaded as tabs in this window.
     </p>
     <div class="uiGrid">
       <div class="label">
@@ -145,7 +145,7 @@
       <div>
       </div>
       <div>
-        <button type="button" id="onlyOneStep" class="browser-style">Evaluate</button>
+        <button type="button" id="evaluate" class="browser-style">Evaluate</button>
       </div>
       <div>
       </div>
@@ -153,9 +153,6 @@
         <meter id="progress" class="hidden"></meter>
       </div>
       <div>
-      </div>
-      <div id="caveats" class="bottommost">
-        Standard window size will be used for consistent sizing of elements. Training is stochastic, so different runs may reach different results.
       </div>
       <div id="output" class="hidden uiGrid">
           <div class="label">
@@ -185,6 +182,6 @@
       </div>
     </div>
     <script src="../utils.js"></script>
-    <script src="../train.js"></script>
+    <script src="../evaluate.js"></script>
   </body>
 </html>

--- a/addon/pages/train.html
+++ b/addon/pages/train.html
@@ -145,8 +145,6 @@
       <div>
       </div>
       <div>
-        <button type="button" id="train" class="browser-style">Train on the tabs in this window</button>
-        <button type="button" id="pause" class="browser-style" disabled="disabled">Pause</button>
         <button type="button" id="onlyOneStep" class="browser-style">Evaluate</button>
       </div>
       <div>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,5 +35,5 @@ function mindlesslyFactoredOutSettings(name) {
 
 export default [
     mindlesslyFactoredOutSettings('contentScript'),
-    mindlesslyFactoredOutSettings('train')
+    mindlesslyFactoredOutSettings('evaluate')
 ];

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -14,9 +14,21 @@ class Evaluator {
                 traineeId: this.traineeId
             }
         )).coeffs;
-        const attempts = await this.resultsForPages(coeffs);
-        const cost = attempts.reduce((accum, value) => accum + value.cost, 0);
-        updateOutputs(coeffs, cost, await this.verboseSuccessReports(coeffs));
+        const successReport = await this.verboseSuccessReports(coeffs);
+        const cost = successReport.reduce((accum, value) => accum + value.cost, 0);
+        updateOutputs(coeffs, cost, successReport);
+    }
+
+    /**
+     * Try the ruleset on each tab, and return a bigger blob of info that
+     * allows us to show the user which element it found, for debugging.
+     */
+    async verboseSuccessReports(coeffs) {
+        return (await this.resultsForPages(coeffs)).map((result, i) => ({
+            didSucceed: result.didSucceed,
+            cost: result.cost,
+            filename: urlFilename(this.tabs[i].url),
+            tabId: this.tabs[i].id}));
     }
 
     /**
@@ -38,17 +50,6 @@ class Evaluator {
                 coeffs: Array.from(coeffs.entries())
             }
         );
-    }
-
-    /**
-     * Try the ruleset on each tab, and return a bigger blob of info that
-     * allows us to show the user which element it found, for debugging.
-     */
-    async verboseSuccessReports(coeffs) {
-        return (await this.resultsForPages(coeffs)).map((result, i) => ({
-            didSucceed: result.didSucceed,
-            filename: urlFilename(this.tabs[i].url),
-            tabId: this.tabs[i].id}));
     }
 
 }

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -1,6 +1,6 @@
 let gProgressBar, gCoeffsDiv, gAccuracyDiv, gCiDiv, gCostDiv, gGoodBadDiv = false;
 
-class Tuner {
+class Evaluator {
     constructor(tabs, traineeId) {
         this.tabs = tabs;
         this.traineeId = traineeId;
@@ -35,7 +35,7 @@ class Tuner {
      *     page
      */
     async resultsForPages(coeffs) {
-        return await browser.runtime.sendMessage(
+        return browser.runtime.sendMessage(
             'fathomtrainees@mozilla.com',
             {type: 'rulesetSucceededOnTabs',
              tabIds: this.tabs.map(tab => tab.id),
@@ -56,9 +56,9 @@ class Tuner {
     }
 }
 
-async function trainOnTabs() {
+async function evaluateTabs() {
     // Grey out Evaluate button:
-    const oneStepButton = document.getElementById('onlyOneStep');
+    const oneStepButton = document.getElementById('evaluate');
     oneStepButton.disabled = true;
 
     // Show progress bar and output.
@@ -67,7 +67,7 @@ async function trainOnTabs() {
 
     try {
         // TODO: Using "active" here rather than a tab ID presents a race condition
-        // if you quickly switch away from the tab after clicking the Train button.
+        // if you quickly switch away from the tab after clicking the Evaluate button.
         const tabs = (await browser.tabs.query({currentWindow: true, active: false}));
         const rulesetName = document.getElementById('ruleset').value;
         const viewportSize = (await browser.runtime.sendMessage(
@@ -75,8 +75,8 @@ async function trainOnTabs() {
             {type: 'trainee',
              traineeId: rulesetName})).viewportSize || {width: 1024, height: 768};
         await setViewportSize(tabs[0], viewportSize.width, viewportSize.height);  // for consistent element sizing in samples due to text wrap, etc.
-        const tuner = new Tuner(tabs, rulesetName);
-        await tuner.anneal(updateProgress);
+        const evaluator = new Evaluator(tabs, rulesetName);
+        await evaluator.anneal(updateProgress);
     } finally {
         // Restore UI state, leaving output visible.
         gProgressBar.classList.add('hidden');
@@ -161,7 +161,7 @@ function updateProgress(ratio, bestSolution, bestCost, successesOrFailures) {
 }
 
 /**
- * Draw and outfit the Train page.
+ * Draw and outfit the Evaluator page.
  */
 async function initPage(document) {
     // Find elements once.
@@ -185,9 +185,9 @@ async function initPage(document) {
     gCiDiv.appendChild(document.createTextNode(''));
     gCostDiv.appendChild(document.createTextNode(''));
 
-    document.getElementById('onlyOneStep').onclick = trainOnTabs;
+    document.getElementById('evaluate').onclick = evaluateTabs;
 
-    initRulesetMenu(document.getElementById('onlyOneStep'));
+    initRulesetMenu(document.getElementById('evaluate'));
 }
 
 initPage(document);


### PR DESCRIPTION
Addresses #43.

This PR rips out the ability to Train and Pause on the Trainer page.

There is certainly work that could be done to clean and re-frame the code as an `Evaluator` instead of a `Tuner`, but I don't know how worth it that is considering #43's end goal is to get rid of the page in the future anyway. If it would be valuable, I'm happy to make the necessary changes.

Regardless, I do think the page itself should be renamed from Trainer to either Tester or Evaluator.