### PR TITLE
Adds a command for freezing a page via keypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Once you have a decent set of coefficients and biases computed, sub them into yo
 
 * Before freezing pages with the Developer Tools panel, use Firefox's Responsive Design mode (command-option-M) to set a repeatable 1024x768 window size. The Vectorizer automatically sets this same size by default. This will ensure that the proper CSS (which may be driven by media queries) will be frozen (and later reloaded) with the page.
 * For maximum fidelity, do your corpus capture in a clean copy of Firefox with no other add-ons. Some ad blockers will make changes to the DOM, like adding style attributes to ad iframes to hide them.
+* You can press `Ctrl+Shift+F` to save and download a page for pages with hover over elements you want visible upon saving.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Once you have a decent set of coefficients and biases computed, sub them into yo
 
 * Before freezing pages with the Developer Tools panel, use Firefox's Responsive Design mode (command-option-M) to set a repeatable 1024x768 window size. The Vectorizer automatically sets this same size by default. This will ensure that the proper CSS (which may be driven by media queries) will be frozen (and later reloaded) with the page.
 * For maximum fidelity, do your corpus capture in a clean copy of Firefox with no other add-ons. Some ad blockers will make changes to the DOM, like adding style attributes to ad iframes to hide them.
-* You can press `Ctrl+Shift+F` to save and download a page for pages with hover over elements you want visible upon saving.
+* You can press `Ctrl+Shift+O` to save and download a page for pages with hover over elements you want visible upon saving.
 
 ## Thanks
 

--- a/addon/background.js
+++ b/addon/background.js
@@ -50,38 +50,28 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
     }
 });
 
-async function freeze_active_tab(tab) {
-    // TODO: Is this try-catch unnecessary since it's being called below in a try-catch?
-    try {
-        await browser.tabs.executeScript(
-            tab.id,
-            {file: '/contentScript.js'}
-        );
-        const html = await browser.tabs.sendMessage(
-            tab.id,
-            {
-                type: 'freeze',
-                options: {
-                    wait: 0,
-                    shouldScroll: false
-                }
+async function freeze_tab(tab) {
+    const html = await browser.tabs.sendMessage(
+        tab.id,
+        {
+            type: 'freeze',
+            options: {
+                wait: 0,
+                shouldScroll: false
             }
-        );
-        await download(html, {saveAs: true});
-    } catch(e) {
-        console.error(e);
-    }
+        }
+    );
+    await download(html, {saveAs: true});
 }
 
 browser.commands.onCommand.addListener((command) => {
-    if (command === "freeze-page") {
+    if (command === 'freeze-page') {
         browser.tabs.query({currentWindow: true, active: true})
             .then((tabs) => {
-                // TODO: There should only be one tab here. Should I handle this a different way?
                 return tabs[0];
             })
             .then((tab) => {
-                return freeze_active_tab(tab);
+                return freeze_tab(tab);
             })
             .catch((error) => {
                 console.log(error);

--- a/addon/background.js
+++ b/addon/background.js
@@ -49,3 +49,42 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
             });
     }
 });
+
+async function freeze_active_tab(tab) {
+    // TODO: Is this try-catch unnecessary since it's being called below in a try-catch?
+    try {
+        await browser.tabs.executeScript(
+            tab.id,
+            {file: '/contentScript.js'}
+        );
+        const html = await browser.tabs.sendMessage(
+            tab.id,
+            {
+                type: 'freeze',
+                options: {
+                    wait: 0,
+                    shouldScroll: false
+                }
+            }
+        );
+        await download(html, {saveAs: true});
+    } catch(e) {
+        console.error(e);
+    }
+}
+
+browser.commands.onCommand.addListener((command) => {
+    if (command === "freeze-page") {
+        browser.tabs.query({currentWindow: true, active: true})
+            .then((tabs) => {
+                // TODO: There should only be one tab here. Should I handle this a different way?
+                return tabs[0];
+            })
+            .then((tab) => {
+                return freeze_active_tab(tab);
+            })
+            .catch((error) => {
+                console.log(error);
+            });
+    }
+});

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -28,5 +28,13 @@
         "downloads",
         "tabs"
     ],
-    "devtools_page": "pages/devtoolsOpener.html"
+    "devtools_page": "pages/devtoolsOpener.html",
+    "commands": {
+        "freeze-page": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+F"
+            },
+            "description": "Download page in current active tab"
+        }
+    }
 }

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -32,7 +32,7 @@
     "commands": {
         "freeze-page": {
             "suggested_key": {
-                "default": "Ctrl+Shift+F"
+                "default": "Ctrl+Shift+O"
             },
             "description": "Download page in current active tab"
         }


### PR DESCRIPTION
Addresses #41 

This PR adds the ability to freeze a page by pressing `Ctrl+Shift+F`. This is useful for pages that have hover elements that you want visible when the page is saved. To my knowledge, this keypress does not conflict with anything else, but let me know if you run into an issue or know of a potential issue.

Also, I have two TODOs in here that are questions on Javascript particulars I am unsure of. I'd love some help in answering those.