### PR TITLE
Parallelize vectorizer

### DIFF
--- a/addon/corpus.js
+++ b/addon/corpus.js
@@ -78,12 +78,16 @@ class CorpusCollector extends PageVisitor {
         return html;
     }
 
-    async processWithoutTimeout(html) {
+    async processWithoutTimeout(html, urlIndex) {
         // Save html to disk.
-        const filename = this.urls[this.urlIndex].filename;
+        const filename = this.urls[urlIndex].filename;
         const download_filename = await download(html, {filename});
 
-        this.setCurrentStatus({message: 'downloaded as ' + download_filename, isFinal: true});
+        this.setCurrentStatus({
+          message: 'downloaded as ' + download_filename,
+          index: urlIndex,
+          isFinal: true
+        });
     }
 }
 

--- a/addon/corpus.js
+++ b/addon/corpus.js
@@ -78,14 +78,14 @@ class CorpusCollector extends PageVisitor {
         return html;
     }
 
-    async processWithoutTimeout(html, urlIndex) {
+    async processWithoutTimeout(html, tabId) {
         // Save html to disk.
-        const filename = this.urls[urlIndex].filename;
+        const filename = this.urls[this.tabIdToUrlsIndex.get(tabId)].filename;
         const download_filename = await download(html, {filename});
 
         this.setCurrentStatus({
           message: 'downloaded as ' + download_filename,
-          index: urlIndex,
+          index: tabId,
           isFinal: true
         });
     }

--- a/addon/corpus.js
+++ b/addon/corpus.js
@@ -61,6 +61,7 @@ class CorpusCollector extends PageVisitor {
     }
 
     async processWithinTimeout(tab, windowId) {
+        this.setCurrentStatus({message: 'freezing', index: tab.id});
         // Inject dispatcher to listen to the message we then send. Can't get a
         // return value directly out of the content script because webpack
         // wraps our top-level stuff in a function. Instead, we use messaging.

--- a/addon/corpus.js
+++ b/addon/corpus.js
@@ -60,7 +60,7 @@ class CorpusCollector extends PageVisitor {
         }
     }
 
-    async processWithinTimeout(tab) {
+    async processWithinTimeout(tab, windowId) {
         // Inject dispatcher to listen to the message we then send. Can't get a
         // return value directly out of the content script because webpack
         // wraps our top-level stuff in a function. Instead, we use messaging.

--- a/addon/pages/vector.html
+++ b/addon/pages/vector.html
@@ -52,7 +52,7 @@
       <div id="options">
         <div>
           <label for="wait" title="Wait this long before vectorizing the page. Sometimes this provides the necessary time for stylesheets to apply, for instance.">Delay:</label>
-          <input class="number" type="text" required pattern="[0-9]+" min="0" size="2" id="wait" value="1"> sec
+          <input class="number" type="text" required pattern="[0-9]+" min="0" size="2" id="wait" value="5"> sec
         </div>
         <div>
           <label for="baseUrl" title="This gets prepended to each page title to make a URL.">Base URL:</label>

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -62,18 +62,8 @@ class CorpusCollector extends PageVisitor {
                 // We often get a "receiving end does not exist", even though
                 // the receiver is a background script that should always be
                 // registered. The error goes away on retrying.
-                if (tries >= maxTries) {  // 3 is not enough.
-                    this.setCurrentStatus({
-                        message: 'failed: ' + error,
-                        index: tab.id,
-                        isError: true,
-                        isFinal: true
-                    });
-                    // Stop everything (no point in continuing if we have an error)
-                    this.doc.dispatchEvent(new CustomEvent(
-                      'fathom:done',
-                      {detail: {windowId: windowId, success: false}}
-                    ));
+                if (tries >= maxTries) {  // 100 is not enough.
+                    this.errorAndStop(`failed: ${error}`, tab.id, windowId);
                     break;
                 } else {
                     await sleep(1000);
@@ -87,17 +77,7 @@ class CorpusCollector extends PageVisitor {
             // This presents as an undefined value in a feature vector.
             const nullFeatures = this.nullFeatures(vector.nodes);
             if (nullFeatures) {
-                this.setCurrentStatus({
-                    message: `failed: rule(s) ${nullFeatures} returned null values`,
-                    index: tab.id,
-                    isError: true,
-                    isFinal: true
-                });
-                // Stop everything (no point in continuing if we have an error)
-                this.doc.dispatchEvent(new CustomEvent(
-                  'fathom:done',
-                  {detail: {windowId: windowId, success: false}}
-                ));
+                this.errorAndStop(`failed: rule(s) ${nullFeatures} returned null values`, tab.id, windowId);
             } else {
                 this.setCurrentStatus({
                     message: 'vectorized',

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -77,13 +77,21 @@ class CorpusCollector extends PageVisitor {
             // This presents as an undefined value in a feature vector.
             const nullFeatures = this.nullFeatures(vector.nodes);
             if (nullFeatures) {
+                // TODO: Probably better to match using tab.url instead of having a magic number.
                 this.setCurrentStatus({
                     message: `failed: rule(s) ${nullFeatures} returned null values`,
+                    index: tab.index - 1,
                     isError: true,
                     isFinal: true
                 });
             } else {
-                this.setCurrentStatus({message: 'vectorized', isFinal: true});
+                // TODO: Probably better to match using tab.url instead of having a magic number.
+                this.setCurrentStatus({message: 'vectorized', index: tab.index - 1, isFinal: true});
+            }
+
+            // TODO: Think of a better way to do this trigger
+            if (this.vectors.length === this.urls.length) {
+              return 'done';
             }
         }
     }

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -44,7 +44,7 @@ class CorpusCollector extends PageVisitor {
         }
     }
 
-    async processWithinTimeout(tab) {
+    async processWithinTimeout(tab, windowId) {
         // Have fathom-trainees vectorize the page:
         let vector = undefined;
         let tries = 0;
@@ -52,6 +52,10 @@ class CorpusCollector extends PageVisitor {
         while (vector === undefined) {
             try {
                 tries++;
+                await browser.tabs.update(
+                  tab.id,
+                  {active: true}
+                );
                 await sleep(this.otherOptions.wait * 1000);
                 vector = await browser.runtime.sendMessage(
                     'fathomtrainees@mozilla.com',

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -63,7 +63,12 @@ class CorpusCollector extends PageVisitor {
                 // the receiver is a background script that should always be
                 // registered. The error goes away on retrying.
                 if (tries >= maxTries) {  // 3 is not enough.
-                    this.setCurrentStatus({message: 'failed: ' + error, isError: true, isFinal: true});
+                    this.setCurrentStatus({
+                        message: 'failed: ' + error,
+                        index: this.getIndexOfURL(tab.url),
+                        isError: true,
+                        isFinal: true
+                    });
                     break;
                 } else {
                     await sleep(1000);

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -65,7 +65,7 @@ class CorpusCollector extends PageVisitor {
                 if (tries >= maxTries) {  // 3 is not enough.
                     this.setCurrentStatus({
                         message: 'failed: ' + error,
-                        index: this.getIndexOfURL(tab.url),
+                        index: tab.id,
                         isError: true,
                         isFinal: true
                     });
@@ -84,7 +84,7 @@ class CorpusCollector extends PageVisitor {
             if (nullFeatures) {
                 this.setCurrentStatus({
                     message: `failed: rule(s) ${nullFeatures} returned null values`,
-                    index: this.getIndexOfURL(tab.url),
+                    index: tab.id,
                     isError: true,
                     isFinal: true
                 });
@@ -96,7 +96,7 @@ class CorpusCollector extends PageVisitor {
             } else {
                 this.setCurrentStatus({
                     message: 'vectorized',
-                    index: this.getIndexOfURL(tab.url),
+                    index: tab.id,
                     isFinal: true
                 });
             }

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -79,11 +79,16 @@ class CorpusCollector extends PageVisitor {
             if (nullFeatures) {
                 this.setCurrentStatus({
                     message: `failed: rule(s) ${nullFeatures} returned null values`,
+                    index: this.getIndexOfURL(tab.url),
                     isError: true,
                     isFinal: true
                 });
             } else {
-                this.setCurrentStatus({message: 'vectorized', isFinal: true});
+                this.setCurrentStatus({
+                    message: 'vectorized',
+                    index: this.getIndexOfURL(tab.url),
+                    isFinal: true
+                });
             }
         }
     }

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -83,6 +83,11 @@ class CorpusCollector extends PageVisitor {
                     isError: true,
                     isFinal: true
                 });
+                // Stop everything (no point in continuing if we have an error)
+                this.doc.dispatchEvent(new CustomEvent(
+                  'fathom:done',
+                  {detail: {windowId: windowId, success: false}}
+                ));
             } else {
                 this.setCurrentStatus({
                     message: 'vectorized',

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -77,21 +77,13 @@ class CorpusCollector extends PageVisitor {
             // This presents as an undefined value in a feature vector.
             const nullFeatures = this.nullFeatures(vector.nodes);
             if (nullFeatures) {
-                // TODO: Probably better to match using tab.url instead of having a magic number.
                 this.setCurrentStatus({
                     message: `failed: rule(s) ${nullFeatures} returned null values`,
-                    index: tab.index - 1,
                     isError: true,
                     isFinal: true
                 });
             } else {
-                // TODO: Probably better to match using tab.url instead of having a magic number.
-                this.setCurrentStatus({message: 'vectorized', index: tab.index - 1, isFinal: true});
-            }
-
-            // TODO: Think of a better way to do this trigger
-            if (this.vectors.length === this.urls.length) {
-              return 'done';
+                this.setCurrentStatus({message: 'vectorized', isFinal: true});
             }
         }
     }

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -48,7 +48,7 @@ class CorpusCollector extends PageVisitor {
         // Have fathom-trainees vectorize the page:
         let vector = undefined;
         let tries = 0;
-        const maxTries = this.otherOptions.retryOnError ? 10 : 1;
+        const maxTries = this.otherOptions.retryOnError ? 100 : 1;
         while (vector === undefined) {
             try {
                 tries++;

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -69,6 +69,11 @@ class CorpusCollector extends PageVisitor {
                         isError: true,
                         isFinal: true
                     });
+                    // Stop everything (no point in continuing if we have an error)
+                    this.doc.dispatchEvent(new CustomEvent(
+                      'fathom:done',
+                      {detail: {windowId: windowId, success: false}}
+                    ));
                     break;
                 } else {
                     await sleep(1000);

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -45,6 +45,7 @@ class CorpusCollector extends PageVisitor {
     }
 
     async processWithinTimeout(tab, windowId) {
+        this.setCurrentStatus({message: 'vectorizing', index: tab.id});
         // Have fathom-trainees vectorize the page:
         let vector = undefined;
         let tries = 0;

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -150,7 +150,7 @@ class PageVisitor {
                 this.setCurrentStatus({message: 'loading', index: tab.id});
             }).catch(error => {
                 // TODO: How to handle a failure in loading the tab since we won't have a status item to display an error for?
-                error.log(error);
+                console.error(error);
             });
         } else {
             // We cannot immediately assume we're done because there may still

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -163,8 +163,8 @@ class PageVisitor {
     async visitPage(event) {
         const windowId = event.detail.windowId;
         const timer = event.detail.timer;
-        const urlIndex = event.detail.urlIndex;
         const tab = (await browser.tabs.get(event.detail.tabId));
+        const urlIndex = this.getIndexOfURL(tab.url);
 
         this.setCurrentStatus({message: 'freezing', index: urlIndex});
         try {

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -195,15 +195,7 @@ class PageVisitor {
             } else if (e.message === 'Message manager disconnected') {
                 error = "tab unexpectedly closed (message manager disconnected)";
             }
-            this.setCurrentStatus({
-                index: tab.id,
-                message: 'freezing failed: ' + error, isError: true, isFinal: true
-            });
-            // Stop everything (no point in continuing if we have an error)
-            this.doc.dispatchEvent(new CustomEvent(
-              'fathom:done',
-              {detail: {windowId: windowId, success: false}}
-            ));
+            this.errorAndStop(`freezing failed: ${error}`, tab.id, windowId);
         }
 
         await browser.tabs.remove(tab.id);
@@ -259,6 +251,20 @@ class PageVisitor {
     // This is used to get the viewport size.
     getViewportHeightAndWidth() {
         throw new Error('You must implement getViewportHeightAndWidth()')
+    }
+
+    errorAndStop(error_message, tabId, windowId) {
+        this.setCurrentStatus({
+            message: error_message,
+            index: tabId,
+            isError: true,
+            isFinal: true
+        });
+        this.doc.dispatchEvent(new CustomEvent(
+          'fathom:done',
+          {detail: {windowId: windowId, success: false}}
+        ));
+
     }
 
     setCurrentStatus({message, index, isFinal=false, isError=false}) {

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -263,14 +263,14 @@ class PageVisitor {
         throw new Error('You must implement getViewportHeightAndWidth()')
     }
 
-    setCurrentStatus({message, tabId, isFinal=false, isError=false}) {
+    setCurrentStatus({message, index, isFinal=false, isError=false}) {
         // Add or update the status entry for the current url in the UI.
         // Messages marked as 'final' cannot be overwritten.
 
-        let li = this.doc.getElementById('u' + tabId);
+        let li = this.doc.getElementById('u' + index);
         if (!li) {
             li = this.doc.createElement('li');
-            li.setAttribute('id', 'u' + tabId);
+            li.setAttribute('id', 'u' + index);
             this.doc.getElementById('status').appendChild(li);
         }
 
@@ -285,7 +285,7 @@ class PageVisitor {
         }
 
         emptyElement(li);
-        const urlObject = this.urls[this.tabIdToUrlsIndex.get(tabId)];
+        const urlObject = this.urls[this.tabIdToUrlsIndex.get(index)];
         const url = (urlObject === undefined) ? 'no URL' : urlObject.url;  // 'no URL' should never happen but comes in handy when avoiding the out-of-bound array access error when debugging this sprawling state machine.
         li.appendChild(this.doc.createTextNode(url + ': ' + message));
         if (isError) {

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -144,10 +144,8 @@ class PageVisitor {
             browser.tabs.create({
                 windowId: windowId,
                 url: this.urls[this.urlIndex].url,
-                active: false,
+                active: true,
             }).then(tab => {
-                console.log(tab);
-                console.log(urlIndexForMap);
                 this.tabIdToUrlsIndex.set(tab.id, urlIndexForMap);
                 this.setCurrentStatus({message: 'loading', index: tab.id});
             }).catch(error => {

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -171,7 +171,6 @@ class PageVisitor {
         const timer = event.detail.timer;
         const tab = (await browser.tabs.get(event.detail.tabId));
 
-        this.setCurrentStatus({message: 'freezing', index: tab.id});
         try {
             const result = await this.processWithinTimeout(tab, windowId);
 

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -145,6 +145,7 @@ class PageVisitor {
             browser.tabs.create({
                 windowId: windowId,
                 url: this.urls[this.urlIndex].url,
+                active: false,
             });
         } else {
             // We cannot immediately assume we're done because there may still

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -135,6 +135,8 @@ class PageVisitor {
 
         if (this.urlIndex < this.urls.length - 1) {
             this.urlIndex++;
+            // Capture the current urlIndex here so we can rely on its value in
+            // the success callback for ``browser.tabs.create()``.
             const urlIndexForMap = this.urlIndex;
             // Create a new tab with the current url.
             // The tabs.onUpdated handler in visitAllPages() will dispatch a fathom:freeze
@@ -148,7 +150,10 @@ class PageVisitor {
                 console.log(urlIndexForMap);
                 this.tabIdToUrlsIndex.set(tab.id, urlIndexForMap);
                 this.setCurrentStatus({message: 'loading', index: tab.id});
-            }).catch(error => console.log(error));
+            }).catch(error => {
+                // TODO: How to handle a failure in loading the tab since we won't have a status item to display an error for?
+                error.log(error);
+            });
         } else {
             // We cannot immediately assume we're done because there may still
             // be some tabs that need to finish up their last url.

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -163,16 +163,17 @@ class PageVisitor {
     async visitPage(event) {
         const windowId = event.detail.windowId;
         const timer = event.detail.timer;
+        const urlIndex = event.detail.urlIndex;
         const tab = (await browser.tabs.get(event.detail.tabId));
 
-        this.setCurrentStatus({message: 'freezing', index: this.getIndexOfURL(tab.url)});
+        this.setCurrentStatus({message: 'freezing', index: urlIndex});
         try {
             const result = await this.processWithinTimeout(tab);
 
             // Clear timeout here so we don't bail out while writing to disk:
             clearTimeout(timer);
 
-            await this.processWithoutTimeout(result);
+            await this.processWithoutTimeout(result, urlIndex);
         } catch (e) {
             // TODO: Is this needed here? I think it is so the real error doesn't get hijacked by a timeout.
             clearTimeout(timer);

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -179,7 +179,6 @@ class PageVisitor {
 
             await this.processWithoutTimeout(result, tab.id);
         } catch (e) {
-            // TODO: Is this needed here? I think it is so the real error doesn't get hijacked by a timeout.
             clearTimeout(timer);
             // Beware: control flow can pass from the very end of the `try` block
             // above to here, for example when "Message manager disconnected"

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -144,7 +144,7 @@ class PageVisitor {
             browser.tabs.create({
                 windowId: windowId,
                 url: this.urls[this.urlIndex].url,
-                active: true,
+                active: false,
             }).then(tab => {
                 this.tabIdToUrlsIndex.set(tab.id, urlIndexForMap);
                 this.setCurrentStatus({message: 'loading', index: tab.id});
@@ -173,7 +173,7 @@ class PageVisitor {
 
         this.setCurrentStatus({message: 'freezing', index: tab.id});
         try {
-            const result = await this.processWithinTimeout(tab);
+            const result = await this.processWithinTimeout(tab, windowId);
 
             // Clear timeout here so we don't bail out while writing to disk:
             clearTimeout(timer);
@@ -224,7 +224,7 @@ class PageVisitor {
     }
 
     // Do per-tab stuff that should be subject to the timeout.
-    async processWithinTimeout(tab) {
+    async processWithinTimeout(tab, windowId) {
     }
 
     // Do per-tab stuff that should happen after the timeout is disabled. This

--- a/addon/visit.js
+++ b/addon/visit.js
@@ -4,9 +4,9 @@
 class PageVisitor {
     constructor(document) {
         this.urls =[];  // Array of {filename, url} to visit
-        this.urlIndex = -1;  // index of current URL in this.urls
-        this.maxTabs = 16;  // Max tabs to have open at one time (may change in start())
-        this.tabsDone = 0;  // Counter for triggering successful done event
+        this.urlIndex = undefined;  // index of current URL in this.urls
+        this.tabsDone = undefined;
+        this.maxTabs = 16;
         this.timeout = undefined;
         this.viewportWidth = undefined;
         this.viewportHeight = undefined;
@@ -55,6 +55,9 @@ class PageVisitor {
 
         this.doc.getElementById('freeze').disabled = true;
         let windowId = 'uninitialized window ID';
+        this.urlIndex = -1;
+        this.tabsDone = 0;
+        this.maxTabs = Math.min(this.maxTabs, this.urls.length);
 
         // Listen for tab events before we start creating tabs; this avoids race
         // conditions between creating tabs and waiting for loading to complete.
@@ -117,12 +120,10 @@ class PageVisitor {
         windowId = (await browser.windows.create({url: '/pages/blank.html'})).id;
     }
 
-    // Start processing by triggering 16 next events. This will load a tab for
-    // each of the first 16 urls in this.urls. If this.urls is less than 16
-    // urls in length, we load them all.
+    // Start processing by triggering ``maxTabs`` next events. This will load
+    // a URL for each event and begin visiting pages in parallel.
     async start(event) {
         const windowId = event.detail;
-        this.maxTabs = Math.min(this.maxTabs, this.urls.length);
         for (let i = 0; i < this.maxTabs; i++) {
             this.doc.dispatchEvent(new CustomEvent(
               'fathom:next',


### PR DESCRIPTION
This PR parallelizes the vectorizer and the corpus collector. This version will load 16 tabs at a time (assuming you're trying to load more than 16 URLs). It is a draft though because I have run into a couple issues I'd like help with.

1. When you first run the vectorizer, you have to accept Firefox's warning about the self signed certificate. When one tab is loaded at a time, this is fine. However, when 16 tabs are loaded, all of them display the warning. When you accept the warning on the tab, that tab runs and then starts loading new tabs, but the other 15 tabs are still waiting for you to accept the warning. Right now, you have to go to each of the 16 tabs to accept the warning. I've found it easier to accept one, refresh the page, and then run the vectorizer again so the warning doesn't come up anymore. Any ideas on how to reduce the friction here? We could open one tab the first time to accept the warning and then launch the rest of the windows, but I'd love a simpler way.
2. Indexing for the status list items used to be done with `urlIndex`. Now, `urlIndex` cannot be relied upon since it can be changes by multiple tabs. Instead, I'm using the URL to index into the list of URLs to figure out which item it was in the array. Unfortunately, if someone has a duplicate URL in their list, the indexing doesn't work. I can't find a way to create a unique ID associating the tab to the URL.
3. I think the corpus collector defaults for `wait` and `timeout` need to be increased.
4. I have a `TODO` in `visit.js` that I am unsure of.