### PR TITLE
Misc changes for fathom vectorize

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -3,6 +3,11 @@
     "name": "FathomFox",
     "version": "3.2",
     "description": "Tools for developing Fathom rulesets",
+    "applications": {
+        "gecko": {
+            "id": "fathomfox@mozilla.com"
+        }
+    },
     "icons": {
         "48": "icons/icon.svg",
         "96": "icons/icon.svg"

--- a/addon/pages/vector.html
+++ b/addon/pages/vector.html
@@ -56,7 +56,7 @@
         </div>
         <div>
           <label for="baseUrl" title="This gets prepended to each page title to make a URL.">Base URL:</label>
-          <input type="text" size="30" id="baseUrl" value="https://localhost:8000/training/">
+          <input type="text" size="30" id="baseUrl" value="http://localhost:8000/">
         </div>
         <div>
           <input type="checkbox" id="retryOnError" checked="checked">


### PR DESCRIPTION
There are a couple changes I'd like to see in FathomFox that make life easier for `fathom-vectorize`.
1. Giving the addon an id allows me to figure out its internal UUID which is needed to navigate to the addon's vectorizer page.
2. The default base URL for the vectorizer has assumed `/training/` for a long time, and I think removing that portion of the URL makes it easier for users using `fathom-list` and for `fathom-vectorize` (which uses `fathom-list`.