### PR TITLE
Merge fathom-trainees into FathomFox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 /addon/web-ext-artifacts
 /addon/evaluate.js
 /addon/simmer.js
-/addon/trainees.js
+/addon/rulesets.js
 /package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /addon/web-ext-artifacts
 /addon/evaluate.js
 /addon/simmer.js
+/addon/trainees.js
 /package-lock.json

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here is an example of how you might use FathomFox to develop a Fathom ruleset th
 
 ### Write and Train a Ruleset
 
-1. Take a first pass at [writing a ruleset](https://mozilla.github.io/fathom/using.html) to recognize the overlays, and put it in `fathom-fox/src/trainees.js`, replacing the example ruleset. (Ultimately, you should keep `trainees.js` with your own project and hard-link it into FathomFox.)
+1. Take a first pass at [writing a ruleset](https://mozilla.github.io/fathom/using.html) to recognize the overlays, and put it in `fathom-fox/src/rulesets.js`, replacing the example ruleset. (Ultimately, you should keep `rulesets.js` with your own project and hard-link it into FathomFox.)
 2. Click the FathomFox icon in the main toolbar, and choose Vectorizer.
 3. Use the Vectorizer to boil down your labeled pages into vectors of floats and save them as a JSON file.
 4. [Use the commandline trainer](https://mozilla.github.io/fathom/training.html#running-the-trainer) to imbibe the vectors and come up with an optimal set of coefficients.
@@ -55,7 +55,7 @@ The Retry on Error checkbox should generally stay on, to work around apparently 
 
 ## Evaluator
 
-Once you have a decent set of coefficients and biases computed, paste them into `trainees.js`, open some troublesome pages in a Firefox window, and invoke the FathomFox Evaluator. From there, click Evaluate to run the ruleset over the loaded tabs. Any pages with misrecognized nodes will show up in red; click those to see which element was wrongly selected. Unfortunately, you need to manually show the dev tools and switch to the Fathom panel once you get to the page in question; there aren't yet web extension APIs to do it automatically. Once you do, you'll see a quick and dirty representation of the "bad" element: a new label called "BAD [the trainee ID]". Be sure to delete this if you choose to re-save the page for some reason. Also note that the BAD label is created only when the bad cell is clicked, for speed; if you navigate to the bad page manually, the label won't be there, or there might be an old label from a previous iteration.
+Once you have a decent set of coefficients and biases computed, paste them into `rulesets.js`, open some troublesome pages in a Firefox window, and invoke the FathomFox Evaluator. From there, click Evaluate to run the ruleset over the loaded tabs. Any pages with misrecognized nodes will show up in red; click those to see which element was wrongly selected. Unfortunately, you need to manually show the dev tools and switch to the Fathom panel once you get to the page in question; there aren't yet web extension APIs to do it automatically. Once you do, you'll see a quick and dirty representation of the "bad" element: a new label called "BAD [the trainee ID]". Be sure to delete this if you choose to re-save the page for some reason. Also note that the BAD label is created only when the bad cell is clicked, for speed; if you navigate to the bad page manually, the label won't be there, or there might be an old label from a previous iteration.
 
 ## Tips
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Once you have a decent set of coefficients and biases computed, paste them into 
 
 Thanks to Treora for his excellent freeze-dry library!
 
+## Development
+
+To work on FathomFox itself, do the steps under "Get FathomFox Running" above.
+
 ## Version History
 
 ### 3.2

--- a/addon/background.js
+++ b/addon/background.js
@@ -18,8 +18,8 @@ function handleBackgroundScriptMessage(request, sender, sendResponse) {
                .then(sendResponse);
         return true;  // so sendResponse hangs around after we return
     } else if (request.type === 'vectorizeTab') {
-        const vector = browser.tabs.sendMessage(request.tabId, request);
-        sendResponse(vector);
+        browser.tabs.sendMessage(request.tabId, request).then(sendResponse);
+        return true;
     } else if (request.type === 'labelBadElement') {
         // Just forward these along to the correct tab:
         browser.tabs.sendMessage(request.tabId, request)

--- a/addon/background.js
+++ b/addon/background.js
@@ -1,4 +1,42 @@
 /**
+  * Handle messages that used to come to the fathom-trainees webext from
+  * FathomFox. It's possible that some of these are no longer needed or that
+  * the indirection is no longer needed. However, in some cases, it's necessary
+  * to dispatch to the background script so we have permission to call the APIs
+  * we need.
+  */
+function handleBackgroundScriptMessage(request, sender, sendResponse) {
+    if (request.type === 'rulesetSucceededOnTabs') {
+        // Run a given ruleset on a given set of tabs, and return an array
+        // of bools saying whether they got the right answer on each.
+        Promise.all(request.tabIds.map(
+                        tabId => browser.tabs.sendMessage(
+                            tabId,
+                            {type: 'rulesetSucceeded',
+                             traineeId: request.traineeId,
+                             coeffs: request.coeffs})))
+               .then(sendResponse);
+        return true;  // so sendResponse hangs around after we return
+    } else if (request.type === 'vectorizeTab') {
+        const vector = browser.tabs.sendMessage(request.tabId, request);
+        sendResponse(vector);
+    } else if (request.type === 'labelBadElement') {
+        // Just forward these along to the correct tab:
+        browser.tabs.sendMessage(request.tabId, request)
+    } else if (request.type === 'traineeKeys') {
+        // Return an array of IDs of rulesets we can train.
+        sendResponse(Array.from(trainees.keys()));
+    } else if (request.type === 'trainee') {
+        // Return all the properties of a trainee that can actually be
+        // serialized and passed over a message.
+        const trainee = Object.assign({}, trainees.get(request.traineeId));  // shallow copy
+        delete trainee.rulesetMaker;  // unserializeable
+        sendResponse(trainee);
+    }
+}
+browser.runtime.onMessage.addListener(handleBackgroundScriptMessage);
+
+/**
  * Connect a dev panel, at its request, to the content script in its inspected
  * tab.
  */

--- a/addon/background.js
+++ b/addon/background.js
@@ -1,8 +1,6 @@
 /**
-  * Handle messages that used to come to the fathom-trainees webext from
-  * FathomFox. It's possible that some of these are no longer needed or that
-  * the indirection is no longer needed. However, in some cases, it's necessary
-  * to dispatch to the background script so we have permission to call the APIs
+  * Dispatch the message that runs a ruleset on all open tabs. It's necessary
+  * to do this in the background script so we have permission to call the APIs
   * we need.
   */
 function handleBackgroundScriptMessage(request, sender, sendResponse) {
@@ -17,18 +15,6 @@ function handleBackgroundScriptMessage(request, sender, sendResponse) {
                              coeffs: request.coeffs})))
                .then(sendResponse);
         return true;  // so sendResponse hangs around after we return
-    } else if (request.type === 'labelBadElement') {
-        // Just forward these along to the correct tab:
-        browser.tabs.sendMessage(request.tabId, request)
-    } else if (request.type === 'traineeKeys') {
-        // Return an array of IDs of rulesets we can train.
-        sendResponse(Array.from(trainees.keys()));
-    } else if (request.type === 'trainee') {
-        // Return all the properties of a trainee that can actually be
-        // serialized and passed over a message.
-        const trainee = Object.assign({}, trainees.get(request.traineeId));  // shallow copy
-        delete trainee.rulesetMaker;  // unserializeable
-        sendResponse(trainee);
     }
 }
 browser.runtime.onMessage.addListener(handleBackgroundScriptMessage);

--- a/addon/background.js
+++ b/addon/background.js
@@ -17,9 +17,6 @@ function handleBackgroundScriptMessage(request, sender, sendResponse) {
                              coeffs: request.coeffs})))
                .then(sendResponse);
         return true;  // so sendResponse hangs around after we return
-    } else if (request.type === 'vectorizeTab') {
-        browser.tabs.sendMessage(request.tabId, request).then(sendResponse);
-        return true;
     } else if (request.type === 'labelBadElement') {
         // Just forward these along to the correct tab:
         browser.tabs.sendMessage(request.tabId, request)

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -18,7 +18,7 @@
     },
     "content_scripts": [{
         "matches": ["<all_urls>"],
-        "js": ["utils.js", "contentScript.js", "simmer.js"]
+        "js": ["trainees.js", "utils.js", "contentScript.js", "simmer.js"]
     }],
     "web_accessible_resources": [
         "simmer.js"

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -23,7 +23,7 @@
     },
     "content_scripts": [{
         "matches": ["<all_urls>"],
-        "js": ["trainees.js", "utils.js", "contentScript.js", "simmer.js"]
+        "js": ["rulesets.js", "utils.js", "contentScript.js", "simmer.js"]
     }],
     "web_accessible_resources": [
         "simmer.js"

--- a/addon/pages/evaluate.html
+++ b/addon/pages/evaluate.html
@@ -178,6 +178,7 @@
           </div>
       </div>
     </div>
+    <script src="../trainees.js"></script>
     <script src="../utils.js"></script>
     <script src="../evaluate.js"></script>
   </body>

--- a/addon/pages/evaluate.html
+++ b/addon/pages/evaluate.html
@@ -130,7 +130,7 @@
   <body class="browser-style" style="padding: 0 20px">
     <h1>Evaluator</h1>
     <p id="please-install" class="warning hidden">
-      No rulesets found. Please install a “trainee” web extension containing your rulesets. For an example, see <a href="https://github.com/mozilla/fathom-trainees">Fathom Trainees</a>.
+      No rulesets found. Please download a source checkout of FathomFox, and define one in trainees.js.
     </p>
     <p>
       Evaluate your ruleset based on the samples you’ve loaded as tabs in this window.

--- a/addon/pages/evaluate.html
+++ b/addon/pages/evaluate.html
@@ -130,7 +130,7 @@
   <body class="browser-style" style="padding: 0 20px">
     <h1>Evaluator</h1>
     <p id="please-install" class="warning hidden">
-      No rulesets found. Please download a source checkout of FathomFox, and define one in trainees.js.
+      No rulesets found. Please download a source checkout of FathomFox, and define one in rulesets.js.
     </p>
     <p>
       Evaluate your ruleset based on the samples you’ve loaded as tabs in this window.
@@ -178,7 +178,7 @@
           </div>
       </div>
     </div>
-    <script src="../trainees.js"></script>
+    <script src="../rulesets.js"></script>
     <script src="../utils.js"></script>
     <script src="../evaluate.js"></script>
   </body>

--- a/addon/pages/vector.html
+++ b/addon/pages/vector.html
@@ -33,7 +33,7 @@
   <body class="browser-style">
     <h1>Vectorizer</h1>
     <p id="please-install" class="warning hidden">
-      No rulesets found. Please install a “trainee” web extension containing your rulesets. For an example, see <a href="https://github.com/mozilla/fathom-trainees">Fathom Trainees</a>.
+      No rulesets found. Please download a source checkout of FathomFox, and define one in trainees.js.
     </p>
     <p>
       This turns a series of frozen, labeled pages into feature vectors for use with <code>fathom-train</code>. The feature vectors land in a file in your usual downloads folder. Because web extensions aren't allowed to load <code>file://</code> URLs, you might find it necessary to run a local web server like <code>fathom-serve</code> in the directory where your local samples live. ``fathom-list`` can help you get a list of filenames to paste here.
@@ -56,7 +56,7 @@
         </div>
         <div>
           <label for="baseUrl" title="This gets prepended to each page title to make a URL.">Base URL:</label>
-          <input type="text" size="30" id="baseUrl" value="https://localhost:8000/training/">
+          <input type="text" size="30" id="baseUrl" value="http://localhost:8000/training/">
         </div>
         <div>
           <input type="checkbox" id="retryOnError" checked="checked">
@@ -66,6 +66,7 @@
     </form>
     <ul id="status"></ul>
     <script src="../download.js"></script>
+    <script src="../trainees.js"></script>
     <script src="../utils.js"></script>
     <script src="../visit.js"></script>
     <script src="../vector.js"></script>

--- a/addon/pages/vector.html
+++ b/addon/pages/vector.html
@@ -33,7 +33,7 @@
   <body class="browser-style">
     <h1>Vectorizer</h1>
     <p id="please-install" class="warning hidden">
-      No rulesets found. Please download a source checkout of FathomFox, and define one in trainees.js.
+      No rulesets found. Please download a source checkout of FathomFox, and define one in rulesets.js.
     </p>
     <p>
       This turns a series of frozen, labeled pages into feature vectors for use with <code>fathom-train</code>. The feature vectors land in a file in your usual downloads folder. Because web extensions aren't allowed to load <code>file://</code> URLs, you might find it necessary to run a local web server like <code>fathom-serve</code> in the directory where your local samples live. ``fathom-list`` can help you get a list of filenames to paste here.
@@ -66,7 +66,7 @@
     </form>
     <ul id="status"></ul>
     <script src="../download.js"></script>
-    <script src="../trainees.js"></script>
+    <script src="../rulesets.js"></script>
     <script src="../utils.js"></script>
     <script src="../visit.js"></script>
     <script src="../vector.js"></script>

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -71,14 +71,7 @@ function sleep(ms) {
 async function initRulesetMenu(goButton) {
     // Draw Ruleset menu:
     let traineeKeys;
-    try {
-        traineeKeys = await browser.runtime.sendMessage(
-            'fathomtrainees@mozilla.com',
-            {type: 'traineeKeys'});
-    } catch (e) {
-        // Fathom Trainees webext is absent.
-        traineeKeys = [];
-    }
+    traineeKeys = Array.from(trainees.keys());
     const menu = document.getElementById('ruleset');
     if (traineeKeys.length) {
         for (const traineeKey of traineeKeys) {

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -53,11 +53,7 @@ class CorpusCollector extends PageVisitor {
             try {
                 tries++;
                 await sleep(this.otherOptions.wait * 1000);
-                vector = await browser.runtime.sendMessage(
-                    // Can we change this to browser.tabs.sendMessage and cut out the middleman?
-                    {type: 'vectorizeTab',
-                     tabId: tab.id,
-                     traineeId: this.traineeId});
+                vector = await browser.tabs.sendMessage(tab.id, {type: 'vectorizeTab', traineeId: this.traineeId});
             } catch (error) {
                 // We often get a "receiving end does not exist", even though
                 // the receiver is a background script that should always be

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -54,7 +54,7 @@ class CorpusCollector extends PageVisitor {
                 tries++;
                 await sleep(this.otherOptions.wait * 1000);
                 vector = await browser.runtime.sendMessage(
-                    'fathomtrainees@mozilla.com',  // Can we change this to browser.tabs.sendMessage and cut out the middleman?
+                    // Can we change this to browser.tabs.sendMessage and cut out the middleman?
                     {type: 'vectorizeTab',
                      tabId: tab.id,
                      traineeId: this.traineeId});

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -54,7 +54,7 @@ class CorpusCollector extends PageVisitor {
                 tries++;
                 await sleep(this.otherOptions.wait * 1000);
                 vector = await browser.runtime.sendMessage(
-                    'fathomtrainees@mozilla.com',
+                    'fathomtrainees@mozilla.com',  // Can we change this to browser.tabs.sendMessage and cut out the middleman?
                     {type: 'vectorizeTab',
                      tabId: tab.id,
                      traineeId: this.traineeId});
@@ -105,13 +105,7 @@ class CorpusCollector extends PageVisitor {
     async processAtBeginningOfRun() {
         this.vectors = [];
         this.traineeId = this.doc.getElementById('ruleset').value;
-        this.trainee = await browser.runtime.sendMessage(
-          'fathomtrainees@mozilla.com',
-          {
-              type: 'trainee',
-              traineeId: this.traineeId
-          }
-        );
+        this.trainee = trainees.get(this.traineeId);
     }
 
     async processAtEndOfRun() {

--- a/addon/vector.js
+++ b/addon/vector.js
@@ -46,7 +46,7 @@ class CorpusCollector extends PageVisitor {
 
     async processWithinTimeout(tab, windowId) {
         this.setCurrentStatus({message: 'vectorizing', index: tab.id});
-        // Have fathom-trainees vectorize the page:
+        // Have the content script vectorize the page:
         let vector = undefined;
         let tries = 0;
         const maxTries = this.otherOptions.retryOnError ? 100 : 1;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fathom-fox",
   "version": "3.2",
-  "description": "Tools for collecting a Fathom training corpus and, eventually, debugging a ruleset",
+  "description": "Tools for collecting a Fathom training corpus and developing rulesets",
   "scripts": {
     "build": "yarn install --ignore-engines && rollup -c",
     "watch": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "license": "MPL-2.0",
   "devDependencies": {
+    "fathom-web": "^3.1.0",
     "freeze-dry": "^0.2.4",
     "rollup": "^1.17.0",
     "rollup-plugin-commonjs": "^10.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,10 @@ function mindlesslyFactoredOutSettings(name) {
                     { src: 'node_modules/simmerjs/dist/simmer.js', dest: 'addon' },
                 ]
             }),
-        ]
+        ],
+        watch: {
+            chokidar: false
+        }
     }
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,13 +9,13 @@ const webpackPostcss = require('./src/rollup-plugin-webpack-postcss/rollup-plugi
 /**
  * Return typical rollup settings for a file of a given name.
  */
-function mindlesslyFactoredOutSettings(name) {
+function mindlesslyFactoredOutSettings(name, globalVarName) {
     return {
         input: 'src/' + name + '.js',
         output: {
             file: 'addon/' + name + '.js',
             format: 'iife',
-            name  // Convention: name the var the same thing.
+            name: globalVarName || name  // Convention: name the var the same thing.
         },
         plugins: [
             resolve({preferBuiltins: true}),
@@ -43,5 +43,5 @@ function mindlesslyFactoredOutSettings(name) {
 export default [
     mindlesslyFactoredOutSettings('contentScript'),
     mindlesslyFactoredOutSettings('evaluate'),
-    mindlesslyFactoredOutSettings('trainees'),
+    mindlesslyFactoredOutSettings('rulesets', 'trainees'),
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,5 +39,6 @@ function mindlesslyFactoredOutSettings(name) {
 
 export default [
     mindlesslyFactoredOutSettings('contentScript'),
-    mindlesslyFactoredOutSettings('evaluate')
+    mindlesslyFactoredOutSettings('evaluate'),
+    mindlesslyFactoredOutSettings('trainees'),
 ];

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -156,8 +156,7 @@ function dispatch(request) {
         case 'rulesetSucceeded':
             try {
                 const ret = runTraineeOnThisDocument(request.traineeId, request.coeffs, {});
-                console.log('runTrainee:', ret);
-                return ret;
+                return Promise.resolve(ret);
             } catch(exc) {
                 throw new Error('Error on ' + window.location + ': ' + exc);
             }

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -166,7 +166,7 @@ function dispatch(request) {
             break;
 
         case 'vectorizeTab':
-            return vectorizeTab(request.traineeId);
+            return Promise.resolve(vectorizeTab(request.traineeId));
 
         default:
             return Promise.resolve({});

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -81,11 +81,11 @@ function runTraineeOnThisDocument(traineeId, serializedCoeffs, moreReturns) {
  */
 function labelBadElement(traineeId, coeffs) {
     const moreReturns = {};
-    const results = runTraineeOnThisDocument(request.traineeId, request.coeffs, moreReturns);
+    const results = runTraineeOnThisDocument(traineeId, coeffs, moreReturns);
 
     // Delete any old labels saying "BAD [this trainee]" that might be lying
     // around so we don't mix the old with the quite-possibly- revised:
-    const badLabel = 'BAD ' + request.traineeId;
+    const badLabel = 'BAD ' + traineeId;
     for (const oldBadNode of document.querySelectorAll('[data-fathom="' + badLabel.replace(/"/g, '\\"') + '"]')) {
         delete oldBadNode.dataset.fathom;
     }

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -18,7 +18,8 @@ class Evaluator {
      * allows us to show the user which element it found, for debugging.
      */
     async verboseSuccessReports(coeffs) {
-        return (await this.resultsForPages(coeffs)).map((result, i) => ({
+        const results = await this.resultsForPages(coeffs);
+        return results.map((result, i) => ({
             didSucceed: result.didSucceed,
             cost: result.cost,
             filename: urlFilename(this.tabs[i].url),
@@ -28,21 +29,21 @@ class Evaluator {
     /**
      * Send a message to all the pages in the corpus, telling them "Run ruleset
      * ID X, and tell me how its default query (the one with the same out() key
-     * as its ID) did." Do it by delegating to the Fathom Trainees webext,
-     * where user rulesets are developed.
+     * as its ID) did."
      *
      * @return an Array of {didSucceed: bool, cost: number} objects, one per
      *     page
      */
-    resultsForPages(coeffs) {
-        return Promise.all(this.tabs.map(
-            tab => browser.tabs.sendMessage(
-                tab.id,
-                {type: 'rulesetSucceeded',
-                 traineeId: this.traineeId,
-                 coeffs: Array.from(coeffs.entries())})));
+    async resultsForPages(coeffs) {
+        return browser.runtime.sendMessage(
+            {
+                type: 'rulesetSucceededOnTabs',
+                tabIds: this.tabs.map(tab => tab.id),
+                traineeId: this.traineeId,
+                coeffs: Array.from(coeffs.entries())
+            }
+        );
     }
-
 }
 
 async function evaluateTabs() {

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -125,11 +125,11 @@ function updateOutputs(coeffs, cost, successesOrFailures) {
             div.firstChild.textContent = sf.filename;
             div.addEventListener('click', function focusTab() {
                 // Label the bad element if bad, clear it if good:
-                browser.runtime.sendMessage(
+                browser.tabs.sendMessage(
+                    sf.tabId,
                     {type: 'labelBadElement',
-                     tabId: sf.tabId,
                      traineeId,
-                     coeffs: coeffs});
+                     coeffs});
                 browser.tabs.update(sf.tabId, {active: true});
                 // Update the Fathom dev tools panel if it's open:
                 browser.runtime.sendMessage({type: 'refresh'});

--- a/src/rulesets.js
+++ b/src/rulesets.js
@@ -3,12 +3,14 @@ import {ancestors, isVisible, linearScale, rgbaFromString, saturation} from 'fat
 
 
 /**
- * Rulesets to vectorize or debug
+ * Rulesets to vectorize or debug (and metadata about them)
  *
- * More mechanically, a map of names to {coeffs, rulesetMaker, ...} objects.
- * See below for details. The rulesets you specify here show up in the
+ * More mechanically, a map of names to {coeffs, rulesetMaker, ...} objects,
+ * which we call "trainees". The rulesets you specify here show up in the
  * FathomFox UI, from which you can debug a ruleset or turn it into vectors for
- * use with the command-line trainer.
+ * use with the command-line trainer. Most often, all the entries here point to
+ * the same ruleset but have different values of `vectorType` for separately
+ * training each type of thing the ruleset recognizes.
  */
 const trainees = new Map();
 

--- a/src/trainees.js
+++ b/src/trainees.js
@@ -1,0 +1,218 @@
+import {ruleset, rule, dom, type, score, out} from 'fathom-web';
+import {ancestors} from 'fathom-web/utilsForFrontend';
+
+
+/**
+ * Rulesets to train.
+ *
+ * More mechanically, a map of names to {coeffs, rulesetMaker, ...} objects.
+ * rulesetMaker is a function that returns a ruleset. coeffs is typically the
+ * best-yet-found set of coefficients for a ruleset. The rulesets you specify
+ * here show up in the FathomFox Trainer UI, from which you can kick off a
+ * training run. However, the neural-net-based trainer is a better bet these
+ * days. The FathomFox Trainer remains because it is a useful debugging tool
+ * when run for 1 iteration, showing what the ruleset chose wrong.
+ */
+const trainees = new Map();
+
+trainees.set(
+    // A ruleset that finds the full-screen, content-blocking overlays that
+    // often go behind modal popups
+    'overlay',
+    {coeffs: new Map([  // [rule name, coefficient]
+        ['big', 50.4946],
+        ['nearlyOpaque', 48.6396],
+        ['monochrome', 42.8406],
+        ['classOrId', 0.5005],
+        ['visible', 55.8750]]),
+     // Bias is -139.3106 for this example, though that isn't needed until
+     // production.
+
+     // viewportSize: {width: 1024, height: 768},
+     //
+     // The content-area size to use while training. Defaults to 1024x768.
+
+     // DEPRECATED:
+     // successFunction: (facts, traineeId) => trueOrFalse,
+     //
+     // By default, elements with a `data-fathom` attribute that matches the
+     // trainee ID are considered a successful find for the ruleset.
+     //
+     // The `successFunction` property allows for alternative success
+     // functions. A success function receives two arguments--a BoundRuleset
+     // and the current trainee ID--and returns whether the ruleset succeeded.
+     //
+     // The default function for this example ruleset is essentially...
+     // successFunction: facts.get('overlay')[0].element.dataset.fathom === 'overlay'
+
+     vectorType: 'overlay',
+     // The type of node to extract features from when using the Vectorizer
+
+     rulesetMaker:
+        function () {
+            /**
+             * Return whether the passed-in div is the size of the whole viewport/document
+             * or nearly so.
+             */
+            function big(fnode) {
+                // Compare the size of the fnode to the size of the viewport. So far, spot-
+                // checking shows the overlay is never the size of the whole document, just
+                // the viewport.
+                const rect = fnode.element.getBoundingClientRect();
+                const hDifference = Math.abs(rect.height - window.innerHeight);
+                const wDifference = Math.abs(rect.width - window.innerWidth);
+                return trapezoid(hDifference + wDifference, 250, 0);  // 250px is getting into "too tall to just be nav or something" territory.
+            }
+
+            /**
+             * Return whether the fnode is almost but not entirely opaque.
+             */
+            function nearlyOpaque(fnode) {
+                const style = getComputedStyle(fnode.element);
+                const opacity = parseFloat(style.getPropertyValue('opacity'));
+                let bgColorAlpha = rgbaFromString(style.getPropertyValue('background-color'))[3];
+                if (bgColorAlpha === undefined) {
+                    bgColorAlpha = 1;
+                }
+                const totalOpacity = opacity * bgColorAlpha;
+                let ret;
+                if (totalOpacity === 1) {  // seems to work even though a float
+                    ret = 0;
+                } else {
+                    ret = trapezoid(totalOpacity, .4, .6);
+                }
+                return ret;
+            }
+
+            /**
+             * Return whether the fnode's bgcolor is nearly black or white.
+             */
+            function monochrome(fnode) {
+                const rgba = rgbaFromString(getComputedStyle(fnode.element).getPropertyValue('background-color'));
+                return trapezoid(1 - saturation(...rgba), .96, 1);
+            }
+
+            function suspiciousClassOrId(fnode) {
+                const element = fnode.element;
+                const attributeNames = ['class', 'id'];
+                let numOccurences = 0;
+                function numberOfSuspiciousSubstrings(value) {
+                    return value.includes('popup') + value.includes('modal') + value.includes('overlay') + value.includes('underlay') + value.includes('backdrop');
+                }
+
+                for (const name of attributeNames) {
+                    let values = element.getAttribute(name);
+                    if (values) {
+                        if (!Array.isArray(values)) {
+                            values = [values];
+                        }
+                        for (const value of values) {
+                            numOccurences += numberOfSuspiciousSubstrings(value);
+                        }
+                    }
+                }
+
+                // 1 occurrence gets us to about 75% certainty; 2, 92%. It bottoms
+                // out at 0 and tops out at 1.
+                // TODO: Figure out how to derive the magic number .1685 from
+                // 0 and 1.
+                return (-(.3 ** (numOccurences + .1685)) + 1);
+            }
+
+            /**
+             * Score hidden things real low.
+             *
+             * For training, this avoids false failures (and thus gives us more
+             * accurate accuracy numbers) since some pages have multiple
+             * popups, all but one of which are hidden in our captures.
+             * However, for actual use, consider dropping this rule, since
+             * deleting popups before they pop up may not be a bad thing.
+             */
+            function visible(fnode) {
+                const element = fnode.element;
+                for (const ancestor of ancestors(element)) {
+                    const style = getComputedStyle(ancestor);
+                    if (style.getPropertyValue('visibility') === 'hidden' ||
+                        style.getPropertyValue('display') === 'none') {
+                        return 0;
+                    }
+                    // Could add opacity and size checks here, but the
+                    // "nearlyOpaque" and "big" rules already deal with opacity
+                    // and size. If they don't do their jobs, maybe repeat
+                    // their work here (so it gets a different coefficient).
+                }
+                return 1;
+            }
+
+            /* Utility procedures */
+
+            /**
+             * Return the extracted [r, g, b, a] values from a string like "rgba(0, 5, 255, 0.8)",
+             * and scale them to 0..1. If no alpha is specified, return undefined for it.
+             */
+            function rgbaFromString(str) {
+                const m = str.match(/^rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*(\d+(?:\.\d+)?)\s*)?\)$/i);
+                if (m) {
+                    return [m[1] / 255, m[2] / 255, m[3] / 255, m[4] === undefined ? undefined : parseFloat(m[4])];
+                } else {
+                    throw new Error("Color " + str + " did not match pattern rgb[a](r, g, b[, a]).");
+                }
+            }
+
+            /**
+             * Scale a number to the range [0, 1].
+             *
+             * For a rising trapezoid, the result is 0 until the input reaches
+             * zeroAt, then increases linearly until oneAt, at which it becomes
+             * 1. To make a falling trapezoid, where the result is 1 to the
+             * left and 0 to the right, use a zeroAt greater than oneAt.
+             */
+            function trapezoid(number, zeroAt, oneAt) {
+                const isRising = zeroAt < oneAt;
+                if (isRising) {
+                    if (number <= zeroAt) {
+                        return 0;
+                    } else if (number >= oneAt) {
+                        return 1;
+                    }
+                } else {
+                    if (number >= zeroAt) {
+                        return 0;
+                    } else if (number <= oneAt) {
+                        return 1;
+                    }
+                }
+                const slope = 1 / (oneAt - zeroAt);
+                return slope * (number - zeroAt);
+            }
+
+            /**
+             * Return the saturation 0..1 of a color defined by RGB values 0..1.
+             */
+            function saturation(r, g, b) {
+                const cMax = Math.max(r, g, b);
+                const cMin = Math.min(r, g, b);
+                const delta = cMax - cMin;
+                const lightness = (cMax + cMin) / 2;
+                const denom = (1 - (Math.abs(2 * lightness - 1)));
+                // Return 0 if it's black (R, G, and B all 0).
+                return (denom === 0) ? 0 : delta / denom;
+            }
+
+            /* The actual ruleset */
+
+            const rules = ruleset([
+                rule(dom('div'), type('overlay')),
+                rule(type('overlay'), score(big), {name: 'big'}),
+                rule(type('overlay'), score(nearlyOpaque), {name: 'nearlyOpaque'}),
+                rule(type('overlay'), score(monochrome), {name: 'monochrome'}),
+                rule(type('overlay'), score(suspiciousClassOrId), {name: 'classOrId'}),
+                rule(type('overlay'), score(visible), {name: 'visible'}),
+                rule(type('overlay').max(), out('overlay'))
+            ]);
+            return rules;
+        }
+    }
+);
+
+export default trainees;

--- a/src/trainees.js
+++ b/src/trainees.js
@@ -1,5 +1,5 @@
 import {ruleset, rule, dom, type, score, out} from 'fathom-web';
-import {ancestors} from 'fathom-web/utilsForFrontend';
+import {ancestors, isVisible, linearScale, rgbaFromString, saturation} from 'fathom-web/utilsForFrontend';
 
 
 /**
@@ -54,7 +54,7 @@ trainees.set(
                 const rect = fnode.element.getBoundingClientRect();
                 const hDifference = Math.abs(rect.height - window.innerHeight);
                 const wDifference = Math.abs(rect.width - window.innerWidth);
-                return trapezoid(hDifference + wDifference, 250, 0);  // 250px is getting into "too tall to just be nav or something" territory.
+                return linearScale(hDifference + wDifference, 250, 0);  // 250px is getting into "too tall to just be nav or something" territory.
             }
 
             /**
@@ -72,7 +72,7 @@ trainees.set(
                 if (totalOpacity === 1) {  // seems to work even though a float
                     ret = 0;
                 } else {
-                    ret = trapezoid(totalOpacity, .4, .6);
+                    ret = linearScale(totalOpacity, .4, .6);
                 }
                 return ret;
             }
@@ -82,7 +82,7 @@ trainees.set(
              */
             function monochrome(fnode) {
                 const rgba = rgbaFromString(getComputedStyle(fnode.element).getPropertyValue('background-color'));
-                return trapezoid(1 - saturation(...rgba), .96, 1);
+                return linearScale(1 - saturation(...rgba), .96, 1);
             }
 
             function suspiciousClassOrId(fnode) {
@@ -112,86 +112,6 @@ trainees.set(
                 return (-(.3 ** (numOccurences + .1685)) + 1);
             }
 
-            /**
-             * Score hidden things real low.
-             *
-             * For training, this avoids false failures (and thus gives us more
-             * accurate accuracy numbers) since some pages have multiple
-             * popups, all but one of which are hidden in our captures.
-             * However, for actual use, consider dropping this rule, since
-             * deleting popups before they pop up may not be a bad thing.
-             */
-            function visible(fnode) {
-                const element = fnode.element;
-                for (const ancestor of ancestors(element)) {
-                    const style = getComputedStyle(ancestor);
-                    if (style.getPropertyValue('visibility') === 'hidden' ||
-                        style.getPropertyValue('display') === 'none') {
-                        return 0;
-                    }
-                    // Could add opacity and size checks here, but the
-                    // "nearlyOpaque" and "big" rules already deal with opacity
-                    // and size. If they don't do their jobs, maybe repeat
-                    // their work here (so it gets a different coefficient).
-                }
-                return 1;
-            }
-
-            /* Utility procedures */
-
-            /**
-             * Return the extracted [r, g, b, a] values from a string like "rgba(0, 5, 255, 0.8)",
-             * and scale them to 0..1. If no alpha is specified, return undefined for it.
-             */
-            function rgbaFromString(str) {
-                const m = str.match(/^rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*(\d+(?:\.\d+)?)\s*)?\)$/i);
-                if (m) {
-                    return [m[1] / 255, m[2] / 255, m[3] / 255, m[4] === undefined ? undefined : parseFloat(m[4])];
-                } else {
-                    throw new Error("Color " + str + " did not match pattern rgb[a](r, g, b[, a]).");
-                }
-            }
-
-            /**
-             * Scale a number to the range [0, 1].
-             *
-             * For a rising trapezoid, the result is 0 until the input reaches
-             * zeroAt, then increases linearly until oneAt, at which it becomes
-             * 1. To make a falling trapezoid, where the result is 1 to the
-             * left and 0 to the right, use a zeroAt greater than oneAt.
-             */
-            function trapezoid(number, zeroAt, oneAt) {
-                const isRising = zeroAt < oneAt;
-                if (isRising) {
-                    if (number <= zeroAt) {
-                        return 0;
-                    } else if (number >= oneAt) {
-                        return 1;
-                    }
-                } else {
-                    if (number >= zeroAt) {
-                        return 0;
-                    } else if (number <= oneAt) {
-                        return 1;
-                    }
-                }
-                const slope = 1 / (oneAt - zeroAt);
-                return slope * (number - zeroAt);
-            }
-
-            /**
-             * Return the saturation 0..1 of a color defined by RGB values 0..1.
-             */
-            function saturation(r, g, b) {
-                const cMax = Math.max(r, g, b);
-                const cMin = Math.min(r, g, b);
-                const delta = cMax - cMin;
-                const lightness = (cMax + cMin) / 2;
-                const denom = (1 - (Math.abs(2 * lightness - 1)));
-                // Return 0 if it's black (R, G, and B all 0).
-                return (denom === 0) ? 0 : delta / denom;
-            }
-
             /* The actual ruleset */
 
             const rules = ruleset([
@@ -200,7 +120,7 @@ trainees.set(
                 rule(type('overlay'), score(nearlyOpaque), {name: 'nearlyOpaque'}),
                 rule(type('overlay'), score(monochrome), {name: 'monochrome'}),
                 rule(type('overlay'), score(suspiciousClassOrId), {name: 'classOrId'}),
-                rule(type('overlay'), score(visible), {name: 'visible'}),
+                rule(type('overlay'), score(isVisible), {name: 'visible'}),
                 rule(type('overlay').max(), out('overlay'))
             ]);
             return rules;

--- a/src/trainees.js
+++ b/src/trainees.js
@@ -28,7 +28,7 @@ trainees.set(
      // Bias is -139.3106 for this example, though that isn't needed until
      // production.
 
-     // viewportSize: {width: 1024, height: 768},
+     viewportSize: {width: 1024, height: 768},
      //
      // The content-area size to use while training. Defaults to 1024x768.
 

--- a/src/trainees.js
+++ b/src/trainees.js
@@ -3,22 +3,29 @@ import {ancestors} from 'fathom-web/utilsForFrontend';
 
 
 /**
- * Rulesets to train.
+ * Rulesets to vectorize or debug
  *
  * More mechanically, a map of names to {coeffs, rulesetMaker, ...} objects.
- * rulesetMaker is a function that returns a ruleset. coeffs is typically the
- * best-yet-found set of coefficients for a ruleset. The rulesets you specify
- * here show up in the FathomFox Trainer UI, from which you can kick off a
- * training run. However, the neural-net-based trainer is a better bet these
- * days. The FathomFox Trainer remains because it is a useful debugging tool
- * when run for 1 iteration, showing what the ruleset chose wrong.
+ * See below for details. The rulesets you specify here show up in the
+ * FathomFox UI, from which you can debug a ruleset or turn it into vectors for
+ * use with the command-line trainer.
  */
 const trainees = new Map();
 
+/**
+ * An example ruleset. Replace it with your own.
+ *
+ * This one finds the full-screen, content-blocking overlays that often go
+ * behind modal popups. It's not the most well-honed thing, but it's simple and
+ * short.
+ */
 trainees.set(
-    // A ruleset that finds the full-screen, content-blocking overlays that
-    // often go behind modal popups
+    // The ID for this ruleset, which must be the same as the Fathom type you
+    // are evaluating, if you are using the Evaluator:
     'overlay',
+
+    // Here we paste in coefficients from fathom-train. This lets us use the
+    // Evaluator to see what Fathom is getting wrong:
     {coeffs: new Map([  // [rule name, coefficient]
         ['big', 50.4946],
         ['nearlyOpaque', 48.6396],
@@ -29,21 +36,7 @@ trainees.set(
      // production.
 
      viewportSize: {width: 1024, height: 768},
-     //
      // The content-area size to use while training. Defaults to 1024x768.
-
-     // DEPRECATED:
-     // successFunction: (facts, traineeId) => trueOrFalse,
-     //
-     // By default, elements with a `data-fathom` attribute that matches the
-     // trainee ID are considered a successful find for the ruleset.
-     //
-     // The `successFunction` property allows for alternative success
-     // functions. A success function receives two arguments--a BoundRuleset
-     // and the current trainee ID--and returns whether the ruleset succeeded.
-     //
-     // The default function for this example ruleset is essentially...
-     // successFunction: facts.get('overlay')[0].element.dataset.fathom === 'overlay'
 
      vectorType: 'overlay',
      // The type of node to extract features from when using the Vectorizer

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,18 +57,26 @@
     "@cliqz-oss/firefox-client" "0.3.1"
     es6-promise "^2.0.1"
 
-"@mrmlnc/readdir-enhanced@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
-  integrity sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==
+"@nodelib/fs.scandir@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.1.tgz#7fa8fed654939e1a39753d286b48b4836d00e0eb"
+  integrity sha512-NT/skIZjgotDSiXs0WqYhgcuBKhUMgfekCmCGtkUAiLqZdOnrdjmZr9wRl3ll64J9NF79uZ4fk16Dx0yMc/Xbg==
   dependencies:
-    call-me-maybe "^1.0.1"
-    glob-to-regexp "^0.3.0"
+    "@nodelib/fs.stat" "2.0.1"
+    run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^1.1.2":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
-  integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+"@nodelib/fs.stat@2.0.1", "@nodelib/fs.stat@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz#814f71b1167390cfcb6a6b3d9cdeb0951a192c14"
+  integrity sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw==
+
+"@nodelib/fs.walk@^1.2.1":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.2.tgz#6a6450c5e17012abd81450eb74949a4d970d2807"
+  integrity sha512-J/DR3+W12uCzAJkw7niXDcqcKBg6+5G5Q/ZpThpGNzAUz70eOR6RV4XnnSN01qHZiVl0eavoxJsBypQoKsV2QQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.1"
+    fastq "^1.6.0"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -129,10 +137,10 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/fs-extra@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-7.0.0.tgz#9c4ad9e1339e7448a76698829def1f159c1b636c"
-  integrity sha512-ndoMMbGyuToTy4qB6Lex/inR98nPiNHacsgMPvy+zqMLgSxbt8VtWpDArpGp69h1fEDQHn1KB+9DWD++wgbwYA==
+"@types/fs-extra@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.0.tgz#d3e2c313ca29f95059f198dd60d1f774642d4b25"
+  integrity sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==
   dependencies:
     "@types/node" "*"
 
@@ -155,10 +163,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.3.tgz#8798d9e39af2fa604f715ee6a6b19796528e46c3"
   integrity sha512-/gwCgiI2e9RzzZTKbl+am3vgNqOt7a9fJ/uxv4SqYKxenoEDNVU3KZEadlpusWhQI0A0dOrZ0T68JYKVjzmgdQ==
 
-"@types/node@^12.6.2":
-  version "12.6.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.6.tgz#831587377c35bb28fa33b6fe5f849a26a3f4a412"
-  integrity sha512-SMgj3x28MkJyHdWaMv/g/ca3LYDi5gR7O8mX0VKazvFOnmlDXctSEdd/8jfSqozjKFK1R9If1QZWkafX7yQTpA==
+"@types/node@^12.6.9":
+  version "12.7.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
+  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
 
 "@types/node@^8.0.7":
   version "8.10.50"
@@ -338,6 +346,11 @@ JSONSelect@0.2.1:
   resolved "https://registry.yarnpkg.com/JSONSelect/-/JSONSelect-0.2.1.tgz#415418a526d33fe31d74b4defa3c836d485ec203"
   integrity sha1-QVQYpSbTP+MddLTe+jyDbUhewgM=
 
+abab@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.2.tgz#a2fba1b122c69a85caa02d10f9270c7219709a9d"
+  integrity sha512-2scffjvioEmNz0OyDSLGWDfKCVwaKc6l9Pm9kOIREU13ClXZvHpg/nRL5xyjSSSLhOnXqft2HpsAzNEEA8cFFg==
+
 abbrev@1, abbrev@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -349,6 +362,14 @@ abstract-leveldown@~0.12.0, abstract-leveldown@~0.12.1:
   integrity sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=
   dependencies:
     xtend "~3.0.0"
+
+acorn-globals@^4.1.0:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
+  integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
+  dependencies:
+    acorn "^6.0.1"
+    acorn-walk "^6.0.1"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"
@@ -362,6 +383,11 @@ acorn-jsx@^5.0.0:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
   integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
 
+acorn-walk@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
+  integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
+
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
@@ -372,12 +398,17 @@ acorn@^5.5.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
   integrity sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==
 
-acorn@^5.7.3:
+acorn@^5.5.3, acorn@^5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.7, acorn@^6.2.0:
+acorn@^6.0.1, acorn@^6.2.1:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
+  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+
+acorn@^6.0.7:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.2.0.tgz#67f0da2fc339d6cfb5d6fb244fd449f33cd8bbe3"
   integrity sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==
@@ -480,7 +511,7 @@ ajv-keywords@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
   integrity sha1-MU3QpLM2j609/NxU7eYXG4htrzw=
 
-ajv-keywords@^3.1.0:
+ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
@@ -683,6 +714,11 @@ array-differ@^3.0.0:
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
   integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
 
+array-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+  integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
+
 array-filter@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
@@ -703,7 +739,7 @@ array-reduce@~0.0.0:
   resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
   integrity sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=
 
-array-union@^1.0.1, array-union@^1.0.2:
+array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
   integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
@@ -786,6 +822,11 @@ async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
+
+async-limiter@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 async@^1.4.0, async@^1.5.2:
   version "1.5.2"
@@ -1006,10 +1047,22 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+braces@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
+
+browser-process-hrtime@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
+  integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
@@ -1155,16 +1208,17 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
-cacache@^11.3.2:
-  version "11.3.3"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.3.tgz#8bd29df8c6a718a6ebd2d010da4d7972ae3bbadc"
-  integrity sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==
+cacache@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.2.tgz#8db03205e36089a3df6954c66ce92541441ac46c"
+  integrity sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==
   dependencies:
     bluebird "^3.5.5"
     chownr "^1.1.1"
     figgy-pudding "^3.5.1"
     glob "^7.1.4"
     graceful-fs "^4.1.15"
+    infer-owner "^1.0.3"
     lru-cache "^5.1.1"
     mississippi "^3.0.0"
     mkdirp "^0.5.1"
@@ -1202,11 +1256,6 @@ cacheable-request@^6.0.0:
     lowercase-keys "^2.0.0"
     normalize-url "^4.1.0"
     responselike "^1.0.2"
-
-call-me-maybe@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
-  integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1334,7 +1383,7 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
   integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
 
-chrome-trace-event@^1.0.0:
+chrome-trace-event@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
   integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
@@ -1478,7 +1527,7 @@ color-name@1.1.1:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
   integrity sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=
 
-colorette@^1.0.8:
+colorette@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.1.0.tgz#1f943e5a357fac10b4e0f5aaef3b14cdc1af6ec7"
   integrity sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==
@@ -1753,6 +1802,18 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
   integrity sha1-lGfQMsOM+u+58teVASUwYvh/ob0=
 
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssstyle@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.4.0.tgz#9d31328229d3c565c61e586b02041a28fccdccf1"
+  integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
+  dependencies:
+    cssom "0.3.x"
+
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
@@ -1778,6 +1839,15 @@ data-uri-to-buffer@2:
   integrity sha512-OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==
   dependencies:
     "@types/node" "^8.0.7"
+
+data-urls@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
+  integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
+  dependencies:
+    abab "^2.0.0"
+    whatwg-mimetype "^2.2.0"
+    whatwg-url "^7.0.0"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -1976,12 +2046,12 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dir-glob@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
-  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
-    path-type "^3.0.0"
+    path-type "^4.0.0"
 
 dispensary@0.37.0:
   version "0.37.0"
@@ -2061,6 +2131,13 @@ domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
   integrity sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=
+
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+  dependencies:
+    webidl-conversions "^4.0.2"
 
 domhandler@^2.3.0:
   version "2.4.2"
@@ -2318,6 +2395,18 @@ escodegen@1.x.x:
   optionalDependencies:
     source-map "~0.6.1"
 
+escodegen@^1.9.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.12.0.tgz#f763daf840af172bb3a2b6dd7219c0e17f7ff541"
+  integrity sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 escope@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
@@ -2335,7 +2424,7 @@ eslint-plugin-no-unsafe-innerhtml@1.0.16:
   dependencies:
     eslint "^3.7.1"
 
-eslint-scope@^4.0.0, eslint-scope@^4.0.3:
+eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
@@ -2642,17 +2731,17 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-glob@^2.2.6:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
-  integrity sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==
+fast-glob@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.0.4.tgz#d484a41005cb6faeb399b951fd1bd70ddaebb602"
+  integrity sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==
   dependencies:
-    "@mrmlnc/readdir-enhanced" "^2.2.1"
-    "@nodelib/fs.stat" "^1.1.2"
-    glob-parent "^3.1.0"
-    is-glob "^4.0.0"
+    "@nodelib/fs.stat" "^2.0.1"
+    "@nodelib/fs.walk" "^1.2.1"
+    glob-parent "^5.0.0"
+    is-glob "^4.0.1"
     merge2 "^1.2.3"
-    micromatch "^3.1.10"
+    micromatch "^4.0.2"
 
 fast-json-patch@^2.0.6:
   version "2.1.0"
@@ -2680,6 +2769,21 @@ fast-safe-stringify@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
   integrity sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==
+
+fastq@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  dependencies:
+    reusify "^1.0.0"
+
+fathom-web@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fathom-web/-/fathom-web-3.1.0.tgz#21ffc8e39c6cfa68272f772476de51ebcc23e281"
+  integrity sha512-XubnFEvTN9nNfqma9eHQOWfPiTj8RivBiwkq0YqWsSe1OJxqxOeFRfm3XdJCpmpCuXUg9xX8y9Fg6uTXb5nJQw==
+  dependencies:
+    jsdom "^11.2.0"
+    wu "^2.1.0"
 
 fd-slicer@~1.1.0:
   version "1.1.0"
@@ -2738,7 +2842,14 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-find-cache-dir@^2.0.0:
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -2875,7 +2986,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-freeze-dry@0.2.4:
+freeze-dry@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/freeze-dry/-/freeze-dry-0.2.4.tgz#c2dbd8027010779b79ff8e71c4ba4ac64ad4651a"
   integrity sha512-8qgnJg5aPaBkKRTpg12laqVz4DQw86rIYoeVGtt+0CKwua7sbTY8DDXAU3STIWmmHTQ8NpplUkF8RmLX9ipV1g==
@@ -2905,12 +3016,12 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   dependencies:
-    graceful-fs "^4.1.2"
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -2978,13 +3089,12 @@ fwd-stream@^1.0.4:
   dependencies:
     readable-stream "~1.0.26-4"
 
-fx-runner@1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/fx-runner/-/fx-runner-1.0.10.tgz#c58ff92d82f620db7bba8633d68423e6385ea69a"
-  integrity sha512-tXj0lMnSey89Dx7R3Lq+HMUy3ODmOmj5lhRYBgMWNOqbh7Vx8vPUiWMbyJ3HIzGuLnNeXAPH0x/GdFZ7h6h0vQ==
+fx-runner@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/fx-runner/-/fx-runner-1.0.11.tgz#528d2d0c3dc8bb05570b506728c4f62e0b0ef095"
+  integrity sha512-igHogHf5wTqqaPPTOav18MMTVq/eoeTJiw/PvPUuwnzU8vbyZInFPgR66G9ZBwvwxC7e611nbtB4xSMcYVhlvg==
   dependencies:
     commander "2.9.0"
-    lodash "4.17.11"
     shell-quote "1.6.1"
     spawn-sync "1.0.15"
     when "3.7.7"
@@ -3104,10 +3214,12 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-to-regexp@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
-  integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+glob-parent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"
+  integrity sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob@7.1.4, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.4"
@@ -3161,6 +3273,20 @@ globals@^9.14.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
+globby@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.1.tgz#4782c34cb75dd683351335c5829cc3420e606b22"
+  integrity sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
+
 globby@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
@@ -3172,20 +3298,6 @@ globby@^5.0.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
-
-globby@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
-  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
-  dependencies:
-    "@types/glob" "^7.1.1"
-    array-union "^1.0.2"
-    dir-glob "^2.2.2"
-    fast-glob "^2.2.6"
-    glob "^7.1.3"
-    ignore "^4.0.3"
-    pify "^4.0.1"
-    slash "^2.0.0"
 
 got@^6.7.1:
   version "6.7.1"
@@ -3230,6 +3342,11 @@ graceful-fs@^4.1.15:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
   integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
+
+graceful-fs@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -3357,6 +3474,13 @@ hosted-git-info@^2.7.1:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
+html-encoding-sniffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
+  integrity sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
+  dependencies:
+    whatwg-encoding "^1.0.1"
+
 htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
@@ -3456,10 +3580,15 @@ ignore@^3.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
   integrity sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==
 
-ignore@^4.0.3, ignore@^4.0.6:
+ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.1:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 immediate@~3.0.5:
   version "3.0.6"
@@ -3493,6 +3622,11 @@ indexof@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
   integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
+
+infer-owner@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
+  integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -3700,7 +3834,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -3757,6 +3891,11 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-obj@^1.0.0:
   version "1.0.1"
@@ -3976,6 +4115,38 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
+jsdom@^11.2.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
+  integrity sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==
+  dependencies:
+    abab "^2.0.0"
+    acorn "^5.5.3"
+    acorn-globals "^4.1.0"
+    array-equal "^1.0.0"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle "^1.0.0"
+    data-urls "^1.0.0"
+    domexception "^1.0.1"
+    escodegen "^1.9.1"
+    html-encoding-sniffer "^1.0.2"
+    left-pad "^1.3.0"
+    nwsapi "^2.0.7"
+    parse5 "4.0.0"
+    pn "^1.1.0"
+    request "^2.87.0"
+    request-promise-native "^1.0.5"
+    sax "^1.2.4"
+    symbol-tree "^3.2.2"
+    tough-cookie "^2.3.4"
+    w3c-hr-time "^1.0.1"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.3"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^6.4.1"
+    ws "^5.2.0"
+    xml-name-validator "^3.0.0"
+
 json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
@@ -4187,6 +4358,11 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+left-pad@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
+  integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
+
 level-blobs@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/level-blobs/-/level-blobs-0.1.7.tgz#9ab9b97bb99f1edbf9f78a3433e21ed56386bdaf"
@@ -4287,12 +4463,12 @@ lie@*, lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-loader-runner@^2.3.0:
+loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -4408,11 +4584,6 @@ lodash.takeright@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.takeright/-/lodash.takeright-4.1.1.tgz#c98d84aa9b80e4d2ff675335a62e02e9a65bb210"
   integrity sha1-yY2EqpuA5NL/Z1M1pi4C6aZbshA=
-
-lodash@4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@^4, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.5:
   version "4.17.14"
@@ -4554,7 +4725,7 @@ memoize-weak@^1.0.2:
   resolved "https://registry.yarnpkg.com/memoize-weak/-/memoize-weak-1.0.2.tgz#d0015a4c7c6cff2263dbbb49db1dc206ebb94916"
   integrity sha1-0AFaTHxs/yJj27tJ2x3CBuu5SRY=
 
-memory-fs@^0.4.0, memory-fs@~0.4.1:
+memory-fs@^0.4.0, memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
@@ -4567,7 +4738,7 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
 
-micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
+micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -4585,6 +4756,14 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -4707,7 +4886,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -4862,7 +5041,7 @@ needle@^2.2.1, needle@^2.2.4:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
-neo-async@^2.5.0:
+neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
@@ -4887,7 +5066,7 @@ node-forge@^0.7.1:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
   integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
 
-node-libs-browser@^2.0.0:
+node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
   integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
@@ -5022,6 +5201,11 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
+nwsapi@^2.0.7:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
+  integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
 
 oauth-sign@~0.8.2:
   version "0.8.2"
@@ -5329,6 +5513,11 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
+parse5@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+  integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+
 parse5@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
@@ -5386,12 +5575,10 @@ path-to-domnode@^1.0.1:
   resolved "https://registry.yarnpkg.com/path-to-domnode/-/path-to-domnode-1.0.1.tgz#8f0e85d997377f9843f8eb187641edaea8893032"
   integrity sha1-jw6F2Zc3f5hD+OsYdkHtrqiJMDI=
 
-path-type@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
-  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
-  dependencies:
-    pify "^3.0.0"
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 pbkdf2@^3.0.3:
   version "3.0.16"
@@ -5413,6 +5600,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picomatch@^2.0.5:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
+  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -5469,6 +5661,11 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
   integrity sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=
+
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+  integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
 po2json@0.4.5:
   version "0.4.5"
@@ -5623,6 +5820,11 @@ psl@^1.1.24:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.2.0.tgz#df12b5b1b3a30f51c329eacbdef98f3a6e136dc6"
   integrity sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==
 
+psl@^1.1.28:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
+  integrity sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
+
 public-encrypt@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.2.tgz#46eb9107206bf73489f8b85b69d91334c6610994"
@@ -5669,7 +5871,7 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -5877,6 +6079,22 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
+request-promise-core@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+  integrity sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==
+  dependencies:
+    lodash "^4.17.11"
+
+request-promise-native@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
+  integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
+  dependencies:
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
 request@2.87.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
@@ -5903,7 +6121,7 @@ request@2.87.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.83.0, request@~2.88.0:
+request@^2.83.0, request@^2.87.0, request@~2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -6012,6 +6230,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+reusify@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -6041,10 +6264,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-commonjs@10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.1.tgz#fbfcadf4ce2e826068e056a9f5c19287d9744ddf"
-  integrity sha512-x0PcCVdEc4J8igv1qe2vttz8JKAKcTs3wfIA3L8xEty3VzxgORLrzZrNWaVMc+pBC4U3aDOb9BnWLAQ8J11vkA==
+rollup-plugin-commonjs@^10.0.1:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.2.tgz#61328f3a29945e2c35f2b2e824c18944fd88a54d"
+  integrity sha512-DxeR4QXTgTOFseYls1V7vgKbrSJmPYNdEMOs0OvH+7+89C3GiIonU9gFrE0u39Vv1KWm3wepq8KAvKugtoM2Zw==
   dependencies:
     estree-walker "^0.6.1"
     is-reference "^1.1.2"
@@ -6052,25 +6275,25 @@ rollup-plugin-commonjs@10.0.1:
     resolve "^1.11.0"
     rollup-pluginutils "^2.8.1"
 
-rollup-plugin-copy@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-copy/-/rollup-plugin-copy-3.0.0.tgz#ef53214ace42d99b765ca998e285920470b5d1d9"
-  integrity sha512-KLXcjur3O5DbCX5NNSFPAGjcncYcEV/sAy4Q6cZvCjW0/hh5TrUeTvrWECVF18EggK64AOAWCeb2kCpwp+1Q+A==
+rollup-plugin-copy@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-copy/-/rollup-plugin-copy-3.1.0.tgz#435589857f4e346ea63fc137d99dcc1b25f51c3b"
+  integrity sha512-oVw3ljRV5jv7Yw/6eCEHntVs9Mc+NFglc0iU0J8ei76gldYmtBQ0M/j6WAkZUFVRSrhgfCrEakUllnN87V2f4w==
   dependencies:
-    "@types/fs-extra" "^7.0.0"
-    colorette "^1.0.8"
-    fs-extra "^7.0.1"
-    globby "^9.2.0"
+    "@types/fs-extra" "^8.0.0"
+    colorette "^1.1.0"
+    fs-extra "^8.1.0"
+    globby "10.0.1"
     is-plain-object "^3.0.0"
 
-rollup-plugin-json@4.0.0:
+rollup-plugin-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-4.0.0.tgz#a18da0a4b30bf5ca1ee76ddb1422afbb84ae2b9e"
   integrity sha512-hgb8N7Cgfw5SZAkb3jf0QXii6QX/FOkiIq2M7BAQIEydjHvTyxXHQiIzZaTFgx1GK0cRCHOCBHIyEkkLdWKxow==
   dependencies:
     rollup-pluginutils "^2.5.0"
 
-rollup-plugin-node-builtins@2.1.2:
+rollup-plugin-node-builtins@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.1.2.tgz#24a1fed4a43257b6b64371d8abc6ce1ab14597e9"
   integrity sha1-JKH+1KQyV7a2Q3HYq8bOGrFFl+k=
@@ -6080,7 +6303,7 @@ rollup-plugin-node-builtins@2.1.2:
     crypto-browserify "^3.11.0"
     process-es6 "^0.11.2"
 
-rollup-plugin-node-globals@1.4.0:
+rollup-plugin-node-globals@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-globals/-/rollup-plugin-node-globals-1.4.0.tgz#5e1f24a9bb97c0ef51249f625e16c7e61b7c020b"
   integrity sha512-xRkB+W/m1KLIzPUmG0ofvR+CPNcvuCuNdjVBVS7ALKSxr3EDhnzNceGkGi1m8MToSli13AzKFYH4ie9w3I5L3g==
@@ -6092,7 +6315,7 @@ rollup-plugin-node-globals@1.4.0:
     process-es6 "^0.11.6"
     rollup-pluginutils "^2.3.1"
 
-rollup-plugin-node-resolve@5.2.0:
+rollup-plugin-node-resolve@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
   integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
@@ -6110,14 +6333,14 @@ rollup-pluginutils@^2.3.1, rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.17.0.tgz#47ee8b04514544fc93b39bae06271244c8db7dfa"
-  integrity sha512-k/j1m0NIsI4SYgCJR4MWPstGJOWfJyd6gycKoMhyoKPVXxm+L49XtbUwZyFsrSU2YXsOkM4u1ll9CS/ZgJBUpw==
+rollup@^1.17.0:
+  version "1.19.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.19.4.tgz#0cb4e4d6fa127adab59b11d0be50e8dd1c78123a"
+  integrity sha512-G24w409GNj7i/Yam2cQla6qV2k6Nug8bD2DZg9v63QX/cH/dEdbNJg8H4lUm5M1bRpPKRUC465Rm9H51JTKOfQ==
   dependencies:
     "@types/estree" "0.0.39"
-    "@types/node" "^12.6.2"
-    acorn "^6.2.0"
+    "@types/node" "^12.6.9"
+    acorn "^6.2.1"
 
 run-async@^0.1.0:
   version "0.1.0"
@@ -6132,6 +6355,11 @@ run-async@^2.2.0:
   integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
     is-promise "^2.1.0"
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -6344,7 +6572,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-simmerjs@0.5.6:
+simmerjs@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/simmerjs/-/simmerjs-0.5.6.tgz#4bba4fd4cbac18d889037aa199dd742dd1402b96"
   integrity sha512-Z00zGHUp2IVSDUuni6gzBxVVQwAEZ7jVHnqL97+2RaHVWTYKfgCNyCvgm68Uc1M6X84hjatxvtOc24Y9ECLPWQ==
@@ -6355,10 +6583,10 @@ simmerjs@0.5.6:
     lodash.take "^4.1.1"
     lodash.takeright "^4.1.1"
 
-slash@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
-  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -6772,6 +7000,11 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -6957,6 +7190,11 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
+symbol-tree@^3.2.2:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -6979,7 +7217,7 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tapable@^1.0.0, tapable@^1.1.0:
+tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
@@ -7030,26 +7268,25 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
-terser-webpack-plugin@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz#69aa22426299f4b5b3775cbed8cb2c5d419aa1d4"
-  integrity sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==
+terser-webpack-plugin@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz#61b18e40eaee5be97e771cdbb10ed1280888c2b4"
+  integrity sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==
   dependencies:
-    cacache "^11.3.2"
-    find-cache-dir "^2.0.0"
+    cacache "^12.0.2"
+    find-cache-dir "^2.1.0"
     is-wsl "^1.1.0"
-    loader-utils "^1.2.3"
     schema-utils "^1.0.0"
     serialize-javascript "^1.7.0"
     source-map "^0.6.1"
-    terser "^4.0.0"
-    webpack-sources "^1.3.0"
+    terser "^4.1.2"
+    webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.1.2.tgz#b2656c8a506f7ce805a3f300a2ff48db022fa391"
-  integrity sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==
+terser@^4.1.2:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.1.4.tgz#4478b6a08bb096a61e793fea1a4434408bab936c"
+  integrity sha512-+ZwXJvdSwbd60jG0Illav0F06GDJF0R4ydZ21Q3wGAFKoBGyJGo34F63vzJHgvYxc1ukOtIjvwEvl9MkjzM6Pg==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -7155,6 +7392,13 @@ to-regex-range@^2.1.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
 
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
@@ -7179,6 +7423,14 @@ tosource@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tosource/-/tosource-1.0.0.tgz#42d88dd116618bcf00d6106dd5446f3427902ff1"
   integrity sha1-QtiN0RZhi88A1hBt1URvNCeQL/E=
+
+tough-cookie@^2.3.3, tough-cookie@^2.3.4:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
 
 tough-cookie@~2.3.3:
   version "2.3.4"
@@ -7335,10 +7587,10 @@ upath@1.1.2, upath@^1.1.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
 
-update-notifier@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-3.0.0.tgz#e9bbf8f0f5b7a2ce6666ca46334fdb29492e8fab"
-  integrity sha512-6Xe3oF2bvuoj4YECUc52yxVs94yWrxwqHbzyveDktTS1WhnlTRpNcQMxUshcB7nRVGi1jEXiqL5cW1S5WSyzKg==
+update-notifier@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-3.0.1.tgz#78ecb68b915e2fd1be9f767f6e298ce87b736250"
+  integrity sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==
   dependencies:
     boxen "^3.0.0"
     chalk "^2.0.1"
@@ -7468,7 +7720,14 @@ vscode-languageserver-types@^3.5.0:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
   integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
 
-watchpack@1.6.0, watchpack@^1.5.0:
+w3c-hr-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+  integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
+  dependencies:
+    browser-process-hrtime "^0.1.2"
+
+watchpack@1.6.0, watchpack@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   integrity sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==
@@ -7484,10 +7743,10 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
-web-ext@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/web-ext/-/web-ext-3.1.0.tgz#58b8fcf113fdc8cc4484142fdb1457cd147de897"
-  integrity sha512-uuJRuAJFHJqHKkfHcZcSPb0ceOsVf/EoLJHynAgFOMxCIPAjbnq7gWT2e792hTpQEMXZE7XsXIeXwqogjLxofA==
+web-ext@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/web-ext/-/web-ext-3.1.1.tgz#457f81cd68fe36e4a0025693aac911dcf9b658a8"
+  integrity sha512-snTfhuxoplm8QAlv+CwOaF0XSaycDUmxsrLfi4NtZRvZ6J79+ijOu9HyTXP0rd1zT3uagWYOBc3ol/ZOsf1LQQ==
   dependencies:
     "@babel/polyfill" "7.4.4"
     "@babel/runtime" "7.4.5"
@@ -7502,7 +7761,7 @@ web-ext@3.1.0:
     es6-error "4.1.1"
     event-to-promise "0.8.0"
     firefox-profile "1.2.0"
-    fx-runner "1.0.10"
+    fx-runner "1.0.11"
     git-rev-sync "1.12.0"
     mkdirp "0.5.1"
     multimatch "4.0.0"
@@ -7516,7 +7775,7 @@ web-ext@3.1.0:
     stream-to-promise "2.2.0"
     strip-json-comments "3.0.1"
     tmp "0.1.0"
-    update-notifier "3.0.0"
+    update-notifier "3.0.1"
     watchpack "1.6.0"
     yargs "13.2.4"
     zip-dir "1.0.2"
@@ -7526,47 +7785,77 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-sources@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
-  integrity sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==
+webpack-sources@^1.4.0, webpack-sources@^1.4.1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
+  integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.36.1:
-  version "4.36.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.36.1.tgz#f546fda7a403a76faeaaa7196c50d12370ed18a9"
-  integrity sha512-Ej01/N9W8DVyhEpeQnbUdGvOECw0L46FxS12cCOs8gSK7bhUlrbHRnWkjiXckGlHjUrmL89kDpTRIkUk6Y+fKg==
+webpack@^4.36.1:
+  version "4.39.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.39.2.tgz#c9aa5c1776d7c309d1b3911764f0288c8c2816aa"
+  integrity sha512-AKgTfz3xPSsEibH00JfZ9sHXGUwIQ6eZ9tLN8+VLzachk1Cw2LVmy+4R7ZiwTa9cZZ15tzySjeMui/UnSCAZhA==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"
     "@webassemblyjs/wasm-edit" "1.8.5"
     "@webassemblyjs/wasm-parser" "1.8.5"
-    acorn "^6.2.0"
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
-    chrome-trace-event "^1.0.0"
+    acorn "^6.2.1"
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
+    chrome-trace-event "^1.0.2"
     enhanced-resolve "^4.1.0"
-    eslint-scope "^4.0.0"
+    eslint-scope "^4.0.3"
     json-parse-better-errors "^1.0.2"
-    loader-runner "^2.3.0"
-    loader-utils "^1.1.0"
-    memory-fs "~0.4.1"
-    micromatch "^3.1.8"
-    mkdirp "~0.5.0"
-    neo-async "^2.5.0"
-    node-libs-browser "^2.0.0"
+    loader-runner "^2.4.0"
+    loader-utils "^1.2.3"
+    memory-fs "^0.4.1"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.1"
+    neo-async "^2.6.1"
+    node-libs-browser "^2.2.1"
     schema-utils "^1.0.0"
-    tapable "^1.1.0"
-    terser-webpack-plugin "^1.1.0"
-    watchpack "^1.5.0"
-    webpack-sources "^1.3.0"
+    tapable "^1.1.3"
+    terser-webpack-plugin "^1.4.1"
+    watchpack "^1.6.0"
+    webpack-sources "^1.4.1"
+
+whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
+  dependencies:
+    iconv-lite "0.4.24"
+
+whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
 whatwg-url@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
   integrity sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
+whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
+whatwg-url@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06"
+  integrity sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
@@ -7692,10 +7981,27 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
+
+wu@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wu/-/wu-2.1.0.tgz#7e72e3fba23e0ff669ddd537e1c857d3d4b1614f"
+  integrity sha1-fnLj+6I+D/Zp3dU34chX09SxYU8=
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
+
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
 xml2js@^0.4.17, xml2js@~0.4.4:
   version "0.4.19"


### PR DESCRIPTION
As per https://github.com/mozilla/fathom-trainees/issues/8

Still have to…

- [x] Update the docs
- [x] Blank out the included ruleset, maybe. (Decided against it because it's nice to have *something* working in there for the sake of our testing and others' orientation, but I did cut it way down.)

After merging…
- [ ] Update the occurrences of "link" (symlink, etc.) in https://mozilla.github.io/fathom/training.html.
- [ ] Ultimately (maybe even soon), I'd like to merge the FathomFox repo into Fathom so we don't have so much push to maintain 2 parallel pieces of documentation. The FathomFox readme would largely be absorbed into the Fathom manual.
- [ ] Hang a sign on fathom-trainees saying it's obsolete.
- [ ] Remove trainees.js from Fathom itself.

Review notes:
* I recommend skimming all the commit messages before descending into a detailed review. (The first commit is big and messy and gets overwritten in a few spots later.)
* We had talked about renaming trainees.js to ruleset.js. I almost did it but then wavered. Is it a big enough gain to bother?