### PR TITLE
Add an isTarget hook for the Vectorizer

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -2,7 +2,7 @@
 function handleBackgroundScriptMessage(request, sender, sendResponse) {
     if (request.type === 'rulesetSucceededOnTabs') {
         // Run a given ruleset on a given set of tabs, and return an array of
-        // bools saying whether they got the right answer on each. It's
+        // responses saying whether they got the right answer on each. It's
         // necessary to do this in the background script so we have permission
         // to call the APIs we need.
         Promise.all(request.tabIds.map(

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -63,6 +63,11 @@ function runTraineeOnThisDocument(traineeId, serializedCoeffs, moreReturns) {
     const trainee = trainees.get(traineeId);
     const facts = trainee.rulesetMaker('dummy').against(window.document);
     facts.setCoeffsAndBiases(serializedCoeffs);
+    // successFunction, used only by the Evaluator, has never been documented
+    // or used and so can be replaced or removed. It is likely
+    // https://github.com/mozilla/fathom- fox/issues/39 will obsolete the
+    // entire Evaluator and show confidences on all found elements rather than
+    // limiting feedback to a single "bad" element.
     const successFunc = trainee.successFunction || foundLabelIsTraineeId;
     const didSucceed = successFunc(facts, traineeId, moreReturns);
     return {didSucceed, cost: moreReturns.cost || (1 - didSucceed)};
@@ -116,10 +121,11 @@ function vectorizeTab(traineeId) {
     const boundRuleset = trainee.rulesetMaker('dummy').against(window.document);
     const fnodes = boundRuleset.get(type(trainee.vectorType));
     const path = window.location.pathname;
+    const isTarget = trainee.isTarget || (fnode => fnode.element.dataset.fathom === traineeId);
     const perNodeStuff = fnodes.map(function featureVectorForFnode(fnode) {
         const scoreMap = fnode.scoresSoFarFor(trainee.vectorType);
         return {
-            isTarget: fnode.element.dataset.fathom === traineeId,
+            isTarget: isTarget(fnode),
             // Loop over ruleset.coeffs in order, and spit out each score:
             features: Array.from(trainee.coeffs.keys()).map(ruleName => scoreMap.get(ruleName))
         };

--- a/src/rulesets.js
+++ b/src/rulesets.js
@@ -127,6 +127,12 @@ trainees.set(
             ]);
             return rules;
         }
+
+     // isTarget is an optional function which returns whether the Vectorizer
+     // should consider a fnode a target. The default is to consider it a
+     // target iff its ``data-fathom`` attribute === the trainee ID.
+     //
+     // isTarget: fnode => fnode.element.dataset.fathom === 'foo'
     }
 );
 

--- a/src/rulesets.js
+++ b/src/rulesets.js
@@ -22,7 +22,7 @@ const trainees = new Map();
  * short.
  */
 trainees.set(
-    // The ID for this ruleset, which must be the same as the Fathom type you
+    // The ID for this trainee, which must be the same as the Fathom type you
     // are evaluating, if you are using the Evaluator:
     'overlay',
 
@@ -37,11 +37,11 @@ trainees.set(
      // Bias is -139.3106 for this example, though that isn't needed until
      // production.
 
-     viewportSize: {width: 1024, height: 768},
      // The content-area size to use while training. Defaults to 1024x768.
+     viewportSize: {width: 1024, height: 768},
 
-     vectorType: 'overlay',
      // The type of node to extract features from when using the Vectorizer
+     vectorType: 'overlay',
 
      rulesetMaker:
         function () {


### PR DESCRIPTION
So we can accept both "new" and "confirm" fields as targets of a single Fathom type