### PR TITLE
Increases the sleep between errors from 1s to 2s

### DIFF
--- a/addon/vector.js
+++ b/addon/vector.js
@@ -66,11 +66,11 @@ class CorpusCollector extends PageVisitor {
                 // We often get a "receiving end does not exist", even though
                 // the receiver is a background script that should always be
                 // registered. The error goes away on retrying.
-                if (tries >= maxTries) {  // 100 is not enough.
+                if (tries >= maxTries) {  // 10 is not enough.
                     this.errorAndStop(`failed: ${error}`, tab.id, windowId);
                     break;
                 } else {
-                    await sleep(1000);
+                    await sleep(2000);
                 }
             }
         }


### PR DESCRIPTION
I ran into an issue with the validation set created by https://github.com/mozilla-services/fathom-login-forms/pull/18 where I had to either increase the number of retries or increase the delay between errors. I chose to increase the delay between errors. I'm making a followup issue to investigate further at a later time.